### PR TITLE
Feature/gonzbnet integrity hardening

### DIFF
--- a/docs/wiki/gonzbnet/administration-and-operations.md
+++ b/docs/wiki/gonzbnet/administration-and-operations.md
@@ -124,6 +124,12 @@ local node block when transport and acceptance should stop immediately. Signed
 events remain available for audit even when their effective projections are
 suppressed.
 
+Tombstones are evaluated as reversible suppression policy. They do not rewrite
+an accepted ReleaseCard or manifest and do not delete a verified cached NZB.
+An expiring tombstone therefore restores eligibility automatically after its
+expiry, assuming the source still passes membership, trust, publication, and
+integrity checks.
+
 Under **Activity > Advanced tools**, the release integrity ledger shows the
 signed and projected titles, source event/body hash, source node and pool,
 membership and node state, publication state, active tombstone, and final

--- a/docs/wiki/gonzbnet/administration-and-operations.md
+++ b/docs/wiki/gonzbnet/administration-and-operations.md
@@ -102,6 +102,49 @@ Use tombstones for signed moderation of federated content. Blocking a node is a
 local transport/acceptance decision and does not rewrite the append-only event
 history.
 
+### Release corrections and suppression
+
+Signed events are immutable. To correct a published title or other metadata:
+
+1. publish the corrected `ReleaseCard` (a title correction normally produces a
+   new stable release ID because normalized title participates in identity);
+2. publish an author-scoped `ReleasePublicationState` with `withdrawn` for the
+   previous release/source and include the reason;
+3. synchronize and confirm the previous source is `withdrawn` and the corrected
+   source is `active` in the release integrity ledger.
+
+For uploader-managed releases, the existing uploader detail view provides the
+pool-specific publish, withdraw, and restore actions that emit these states.
+
+Withdrawal controls only the publisher's own source. For malicious content or
+a source the publisher cannot be trusted to withdraw, a pool administrator can
+tombstone the release, manifest, event, node, or pool member. Revoke the
+member's pool roles/capabilities to stop future accepted publication and apply a
+local node block when transport and acceptance should stop immediately. Signed
+events remain available for audit even when their effective projections are
+suppressed.
+
+Under **Activity > Advanced tools**, the release integrity ledger shows the
+signed and projected titles, source event/body hash, source node and pool,
+membership and node state, publication state, active tombstone, and final
+effective state. It can be filtered by pool, node, release, or state and uses a
+stable cursor for pagination. Event diagnostics can be filtered by pool, author
+node, event type, validation status, projection status, and active tombstone
+status.
+
+Equivalent local-admin API reads are:
+
+```text
+GET /api/v1/admin/gonzbnet/diagnostics/releases?pool_id=POOL&node_id=NODE&state=active
+GET /api/v1/admin/gonzbnet/diagnostics/releases?pool_id=POOL&state=tombstoned
+GET /api/v1/admin/gonzbnet/diagnostics/events?pool_id=POOL&node_id=NODE&tombstoned=true
+GET /api/v1/admin/gonzbnet/moderation/tombstones?active=true
+```
+
+The ledger is the observing node's local view. Compare nodes when diagnosing
+sync convergence; changing one aggregator's database does not mutate another
+node or create a new federation event.
+
 ## Metrics
 
 Authenticated local-admin endpoints expose process-local metrics and bounded
@@ -127,7 +170,9 @@ required.
 
 Useful operational signals include accepted/rejected events, signature and
 authorization failures, pull/push delivery results, manifest fetch/cache
-outcomes, admission status, validation work, and stale coverage claims.
+outcomes, cache-integrity failures, admission status, validation work, and stale
+coverage claims. `gonzbnet_manifest_cache_integrity_failures_total` increments
+when a PostgreSQL or filesystem NZB cache payload fails its checksum.
 
 ## Troubleshooting
 
@@ -164,6 +209,10 @@ outcomes, admission status, validation work, and stale coverage claims.
 - Confirm the card has a stable manifest ID and at least one authorized source.
 - Check manifest availability, source health, fetch timeout, response-size
   limit, signature validation, and cache policy.
+- Inspect the release integrity ledger for a blocked/revoked/withdrawn source,
+  active tombstone, or signed/projection mismatch.
+- Check `gonzbnet_manifest_cache_integrity_failures_total`; a corrupt cache entry
+  is repaired from its verified signed manifest or discarded and refetched.
 - A publisher needs `manifest_builder_enabled` to create locally sourced signed
   manifests.
 

--- a/docs/wiki/gonzbnet/architecture-and-data-flow.md
+++ b/docs/wiki/gonzbnet/architecture-and-data-flow.md
@@ -89,6 +89,12 @@ On a local get request, the resolver:
 6. caches the accepted manifest under the byte and TTL policy;
 7. renders the NZB locally.
 
+Manifest content is deduplicated by manifest ID, while the signed source event
+is recorded separately for each pool and author. This preserves the exact
+pool-bound envelope when identical manifest content is published to multiple
+pools. Cached NZB bytes are rehashed before use and repaired deterministically
+from the verified signed manifest if local storage has changed.
+
 The shared aggregator cache is not an authorization shortcut. Pool access is
 checked before cached GoNZBNet content is served.
 

--- a/docs/wiki/gonzbnet/federation-protocol-and-security.md
+++ b/docs/wiki/gonzbnet/federation-protocol-and-security.md
@@ -65,6 +65,13 @@ tolerance, maximum event age, nonce lifetime, body limits, and request rate.
 Nonces prevent a valid signed request from being replayed within its acceptance
 window.
 
+These signatures authenticate the requesting node and protect request
+integrity; they are not PGP-style encryption. HTTPS supplies confidentiality
+and server transport authentication. A `ManifestRequest` is signed by the
+requesting node, binds its declared `requesting_node_id` to that signature, and
+names the exact manifest, release, and pool. The response echoes the random
+request ID so a valid response cannot be substituted between concurrent grabs.
+
 Discovery metadata remains public, but event streams, pool membership, pool
 checkpoints, manifests, coverage mutation, and optional peer exchange require
 the appropriate authenticated node and pool relationship.
@@ -160,10 +167,40 @@ content during typed validation. Cards and manifests reject local-only fields,
 invalid source/pool relationships, malformed message IDs, negative sizes, and
 unsupported policy values.
 
-Manifest resolution authorizes the local role before cache access. Remote fetch
-authenticates only the home node, verifies the signed manifest response, and
-applies configured response-size and timeout limits. `ManifestAvailability`
-statements update only their matching source, pool, release, and manifest.
+Manifest resolution authorizes the local role before cache access. The home
+aggregator selects an eligible advertised source, sends the signed
+`ManifestRequest`, verifies the returned `ResolutionManifest` event, and then
+generates the NZB locally. A peer does not return an unsigned pre-generated NZB.
+Resolution requires all of these bindings to agree:
+
+- response request ID;
+- requested, advertised, and signed release and manifest IDs;
+- selected pool and the signed event's single pool;
+- selected serving node, signed author, current membership/capabilities, node
+  block/fork state, publication state, trust threshold, and tombstones.
+
+The complete typed event-body validator runs before the manifest is cached.
+The cache record is also required to match its stored signed source event.
+PostgreSQL NZB bytes are hashed on every read; a mismatch is regenerated
+deterministically from the verified signed manifest or failed closed when that
+provenance is unavailable. The optional filesystem NZB cache is checked against
+the PostgreSQL checksum before use. These checks are local and add no federation
+messages or background polling.
+
+`ManifestAvailability` statements update only their matching source, pool,
+release, and manifest. Search, get, and cache queries apply current source
+eligibility at read time, so blocking a node, revoking its membership,
+withdrawing its source, disabling a pool, or activating a relevant tombstone
+suppresses it without rewriting signed history. Search/get also compare the
+projected ReleaseCard metadata with its accepted signed source event; a locally
+modified title or detail is excluded and reported as a projection mismatch.
+
+Signatures establish who published exact bytes; they do not establish that a
+title is truthful, Message-IDs reference desirable content, or articles are
+malware-free. A malicious authorized publisher can sign internally consistent
+poison. Pool capability grants, independent validation, trust scores,
+moderation, author-scoped withdrawal, member revocation, and local blocking are
+the policy controls for that threat.
 
 Local Newznab API keys and sessions are not included in federation events,
 requests, or logs. The E2E suite explicitly checks that a generated local API

--- a/docs/wiki/indexer/stage-ownership.md
+++ b/docs/wiki/indexer/stage-ownership.md
@@ -16,7 +16,9 @@
   release lineage tables.
 - Uploader approval owns only `source_kind = uploader` rows in the terminal
   `releases`, `release_catalog_files`, and `release_newsgroups` catalog. These
-  rows are catalog projections, not release-formation output.
+  rows are catalog projections, not release-formation output. They are excluded
+  from automatic GoNZBNet indexer publication; federation publication remains
+  an explicit uploader action.
 - Inspect stages own inspection history, artifacts, archive entries, text/media
   evidence, PAR2 sets, PAR2 targets, and their ready queue.
 - Release persistence publishes inspection-ready events. A durable

--- a/internal/aggregator/manager.go
+++ b/internal/aggregator/manager.go
@@ -219,7 +219,33 @@ func (m *Manager) GetNZB(ctx context.Context, rel *domain.Release) (io.ReadClose
 			}
 		}
 
-		return m.store.GetNZBReader(rel.ID)
+		reader, readErr := m.store.GetNZBReader(rel.ID)
+		if validator, ok := src.(cachedPayloadValidator); ok {
+			if readErr == nil {
+				payload, payloadErr := io.ReadAll(io.LimitReader(reader, maxCachedNZBBytes+1))
+				_ = reader.Close()
+				if payloadErr == nil && int64(len(payload)) <= maxCachedNZBBytes {
+					if validationErr := validator.ValidateCachedNZB(ctx, rel, payload); validationErr == nil {
+						return io.NopCloser(bytes.NewReader(payload)), nil
+					} else {
+						m.logger.Warn("Rejected cached NZB for %s: %v", rel.ID, validationErr)
+					}
+				} else if payloadErr != nil {
+					m.logger.Warn("Failed reading cached NZB for %s: %v", rel.ID, payloadErr)
+				} else {
+					m.logger.Warn("Rejected oversized cached NZB for %s", rel.ID)
+				}
+			} else {
+				m.logger.Warn("Failed opening cached NZB for %s: %v", rel.ID, readErr)
+			}
+			// Fail closed for the cached bytes and continue through the source;
+			// a successful fetch below atomically replaces the bad entry.
+		} else {
+			if readErr != nil {
+				return nil, readErr
+			}
+			return reader, nil
+		}
 	}
 	// This calls either the raw DownloadNZB or the local store indexer.
 	body, err := src.GetNZB(ctx, rel)

--- a/internal/aggregator/manager_test.go
+++ b/internal/aggregator/manager_test.go
@@ -140,6 +140,27 @@ func TestGetNZBReturnsAuthorizedGoNZBNetBlobCache(t *testing.T) {
 	}
 }
 
+func TestGetNZBRejectsInvalidGoNZBNetBlobCacheAndRefetches(t *testing.T) {
+	store := &fakeManagerStore{exists: true, cachePayload: []byte("tampered")}
+	manager := NewManager(store, fakeLogger{}, true, false)
+	source := &fakeCatalogSource{name: gonzbnetSourceName, validateCachedErr: io.ErrUnexpectedEOF}
+	manager.AddSource(source)
+	ctx := auth.ContextWithPrincipal(context.Background(), &auth.Principal{
+		Permissions: map[string]struct{}{auth.PermissionGoNZBNetGet: {}},
+	})
+
+	reader, err := manager.GetNZB(ctx, &domain.Release{
+		ID: "cached-federated-result", Source: gonzbnetSourceName, GUID: "rel_fed",
+	})
+	if err != nil {
+		t.Fatalf("refetch invalid cached NZB: %v", err)
+	}
+	_ = reader.Close()
+	if source.validateCachedCalls != 1 || source.gets != 1 || store.cacheWrites != 1 {
+		t.Fatalf("expected invalid cache to be replaced: validations=%d gets=%d writes=%d", source.validateCachedCalls, source.gets, store.cacheWrites)
+	}
+}
+
 func TestGetResultByIDUsesAuthoritativeDirectSourceWithoutPriorSearch(t *testing.T) {
 	manager := NewManager(&fakeManagerStore{}, fakeLogger{}, false, false)
 	source := &fakeCatalogSource{
@@ -161,14 +182,18 @@ type fakeManagerStore struct {
 	searchResults []*domain.Release
 	exists        bool
 	cacheReads    int
+	cacheWrites   int
+	cachePayload  []byte
 }
 
 func (s *fakeManagerStore) GetNZBReader(string) (io.ReadCloser, error) {
 	s.cacheReads++
-	return io.NopCloser(bytes.NewReader(nil)), nil
+	return io.NopCloser(bytes.NewReader(s.cachePayload)), nil
 }
 
-func (s *fakeManagerStore) SaveNZBAtomically(string, []byte) error {
+func (s *fakeManagerStore) SaveNZBAtomically(_ string, payload []byte) error {
+	s.cacheWrites++
+	s.cachePayload = append([]byte(nil), payload...)
 	return nil
 }
 
@@ -196,12 +221,14 @@ func (fakeLogger) Warn(string, ...interface{})  {}
 func (fakeLogger) Error(string, ...interface{}) {}
 
 type fakeCatalogSource struct {
-	name           string
-	direct         *domain.Release
-	directGets     int
-	gets           int
-	authorizeCalls int
-	authorizeErr   error
+	name                string
+	direct              *domain.Release
+	directGets          int
+	gets                int
+	authorizeCalls      int
+	authorizeErr        error
+	validateCachedCalls int
+	validateCachedErr   error
 }
 
 func (s *fakeCatalogSource) GetByID(_ context.Context, id string) (*domain.Release, error) {
@@ -229,4 +256,9 @@ func (s *fakeCatalogSource) GetNZB(context.Context, *domain.Release) (io.ReadClo
 func (s *fakeCatalogSource) AuthorizeGet(context.Context, *domain.Release) error {
 	s.authorizeCalls++
 	return s.authorizeErr
+}
+
+func (s *fakeCatalogSource) ValidateCachedNZB(context.Context, *domain.Release, []byte) error {
+	s.validateCachedCalls++
+	return s.validateCachedErr
 }

--- a/internal/aggregator/source.go
+++ b/internal/aggregator/source.go
@@ -49,6 +49,12 @@ type getAuthorizer interface {
 	AuthorizeGet(ctx context.Context, rel *domain.Release) error
 }
 
+// cachedPayloadValidator lets policy-aware sources bind a shared filesystem
+// cache entry to their authoritative content checksum before any bytes leave.
+type cachedPayloadValidator interface {
+	ValidateCachedNZB(ctx context.Context, rel *domain.Release, payload []byte) error
+}
+
 type store interface {
 	GetNZBReader(id string) (io.ReadCloser, error)
 	SaveNZBAtomically(id string, data []byte) error

--- a/internal/aggregator/sources/gonzbnet/source.go
+++ b/internal/aggregator/sources/gonzbnet/source.go
@@ -2,6 +2,8 @@ package gonzbnet
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"strconv"
@@ -12,6 +14,7 @@ import (
 	"github.com/datallboy/gonzb/internal/auth"
 	"github.com/datallboy/gonzb/internal/categories/newsnab"
 	"github.com/datallboy/gonzb/internal/domain"
+	gonzbnetmetrics "github.com/datallboy/gonzb/internal/gonzbnet/metrics"
 	"github.com/datallboy/gonzb/internal/store/pgindex"
 )
 
@@ -21,6 +24,7 @@ type Store interface {
 	ListFederationSearchPoolsForPrincipal(ctx context.Context, userID string, roleIDs []string) ([]string, error)
 	CanGetFederatedReleaseForPrincipal(ctx context.Context, releaseID, userID string, roleIDs []string) (bool, error)
 	SearchFederatedReleaseCards(ctx context.Context, params pgindex.FederatedReleaseCardSearchParams) ([]pgindex.FederatedReleaseCardSummary, error)
+	GetFederatedNZBSHA256ByReleaseID(ctx context.Context, releaseID string) (string, bool, error)
 }
 
 type Source struct {
@@ -116,6 +120,27 @@ func (s *Source) AuthorizeGet(ctx context.Context, rel *domain.Release) error {
 	}
 	if !allowed {
 		return fmt.Errorf("gonzbnet pool get and resolve access is required")
+	}
+	return nil
+}
+
+func (s *Source) ValidateCachedNZB(ctx context.Context, rel *domain.Release, payload []byte) error {
+	if s == nil || s.store == nil || rel == nil || strings.TrimSpace(rel.GUID) == "" {
+		return fmt.Errorf("gonzbnet cached release is required")
+	}
+	expected, ok, err := s.store.GetFederatedNZBSHA256ByReleaseID(ctx, strings.TrimSpace(rel.GUID))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		gonzbnetmetrics.Default.Add(gonzbnetmetrics.ManifestCacheIntegrityFailuresTotal, 1)
+		return fmt.Errorf("verified gonzbnet cache checksum is unavailable")
+	}
+	sum := sha256.Sum256(payload)
+	actual := "sha256:" + hex.EncodeToString(sum[:])
+	if !strings.EqualFold(strings.TrimSpace(expected), actual) {
+		gonzbnetmetrics.Default.Add(gonzbnetmetrics.ManifestCacheIntegrityFailuresTotal, 1)
+		return fmt.Errorf("gonzbnet filesystem cache checksum mismatch")
 	}
 	return nil
 }

--- a/internal/aggregator/sources/gonzbnet/source_test.go
+++ b/internal/aggregator/sources/gonzbnet/source_test.go
@@ -182,6 +182,10 @@ func (s *fakeStore) SearchFederatedReleaseCards(_ context.Context, params pginde
 	return append([]pgindex.FederatedReleaseCardSummary(nil), s.cards...), nil
 }
 
+func (s *fakeStore) GetFederatedNZBSHA256ByReleaseID(context.Context, string) (string, bool, error) {
+	return "", false, nil
+}
+
 type fakeResolver struct {
 	calls int
 }

--- a/internal/api/controllers/gonzbnet.go
+++ b/internal/api/controllers/gonzbnet.go
@@ -98,7 +98,7 @@ type gonzbnetStore interface {
 	SuggestCoverageWork(ctx context.Context, params pgindex.CoverageWorkSuggestionParams) ([]pgindex.CoverageWorkSuggestion, error)
 	BuildCoverageSchedulerPlan(ctx context.Context, params pgindex.CoverageWorkSuggestionParams) (pgindex.CoverageSchedulerPlan, error)
 	GetResolutionManifest(ctx context.Context, manifestID string) (*manifest.ResolutionManifest, error)
-	GetResolutionManifestEvent(ctx context.Context, manifestID string) (*events.SignedEvent, error)
+	GetResolutionManifestEvent(ctx context.Context, manifestID, poolID string) (*events.SignedEvent, error)
 	CanFetchResolutionManifest(ctx context.Context, manifestID, nodeID string) (bool, error)
 	CanFetchResolutionManifestForSource(ctx context.Context, manifestID, releaseID, poolID, nodeID string) (bool, error)
 	ProjectHealthAttestation(ctx context.Context, projection pgindex.HealthAttestationProjection) error
@@ -1612,7 +1612,7 @@ func (ctrl *GoNZBNetController) RequestManifest(c *echo.Context) error {
 			Message:       "Requesting node is not authorized for this manifest",
 		})
 	}
-	event, err := store.GetResolutionManifestEvent(c.Request().Context(), manifestID)
+	event, err := store.GetResolutionManifestEvent(c.Request().Context(), manifestID, req.PoolID)
 	if err != nil {
 		return federationJSONError(c, http.StatusInternalServerError, "internal_error", err.Error())
 	}

--- a/internal/api/controllers/gonzbnet.go
+++ b/internal/api/controllers/gonzbnet.go
@@ -100,6 +100,7 @@ type gonzbnetStore interface {
 	GetResolutionManifest(ctx context.Context, manifestID string) (*manifest.ResolutionManifest, error)
 	GetResolutionManifestEvent(ctx context.Context, manifestID string) (*events.SignedEvent, error)
 	CanFetchResolutionManifest(ctx context.Context, manifestID, nodeID string) (bool, error)
+	CanFetchResolutionManifestForSource(ctx context.Context, manifestID, releaseID, poolID, nodeID string) (bool, error)
 	ProjectHealthAttestation(ctx context.Context, projection pgindex.HealthAttestationProjection) error
 	ProjectTrustAttestation(ctx context.Context, projection pgindex.TrustAttestationProjection) error
 	ProjectValidatorCapacity(ctx context.Context, projection pgindex.ValidatorCapacityProjection) error
@@ -1573,6 +1574,9 @@ func (ctrl *GoNZBNetController) RequestManifest(c *echo.Context) error {
 	if err := decodeFederationJSON(body, &req); err != nil {
 		return federationJSONError(c, http.StatusBadRequest, "invalid_json", "invalid manifest request json")
 	}
+	if err := manifest.ValidateRequest(req, time.Now().UTC(), time.Duration(cfg.TimeToleranceSeconds)*time.Second); err != nil {
+		return federationJSONError(c, http.StatusBadRequest, "invalid_schema", err.Error())
+	}
 	manifestID := pathParamTrimmed(c, "manifest_id")
 	if req.ManifestID != manifestID {
 		return c.JSON(http.StatusBadRequest, manifest.Response{
@@ -1594,7 +1598,7 @@ func (ctrl *GoNZBNetController) RequestManifest(c *echo.Context) error {
 			Message:       "requesting node does not match request signature",
 		})
 	}
-	allowed, err := store.CanFetchResolutionManifest(c.Request().Context(), manifestID, verified.NodeID)
+	allowed, err := store.CanFetchResolutionManifestForSource(c.Request().Context(), manifestID, req.ReleaseID, req.PoolID, verified.NodeID)
 	if err != nil {
 		return federationJSONError(c, http.StatusInternalServerError, "internal_error", err.Error())
 	}

--- a/internal/api/controllers/gonzbnet_admin.go
+++ b/internal/api/controllers/gonzbnet_admin.go
@@ -74,12 +74,13 @@ type gonzbnetAdminStore interface {
 	ListValidationGaps(ctx context.Context, poolID string, limit int) ([]pgindex.ValidationGap, error)
 	MaterializeCoverageStaleClaimPenalties(ctx context.Context, poolID string) (int64, error)
 	ListFederationPeerDiagnostics(ctx context.Context, limit int) ([]pgindex.FederationPeerDiagnostic, error)
-	ListFederationEventDiagnostics(ctx context.Context, limit int) ([]pgindex.FederationEventDiagnostic, error)
+	ListFederationEventDiagnostics(ctx context.Context, params pgindex.FederationEventDiagnosticParams) ([]pgindex.FederationEventDiagnostic, error)
 	ListFederationRejectedEventDiagnostics(ctx context.Context, limit int) ([]pgindex.FederationRejectedEventDiagnostic, error)
 	ListFederationRejectedEventSummary(ctx context.Context, limit int) ([]pgindex.FederationRejectedEventSummary, error)
 	ListFederationPeerDeliveryDiagnostics(ctx context.Context, limit int) ([]pgindex.FederationPeerDeliveryDiagnostic, error)
 	ListValidationTaskDiagnostics(ctx context.Context, limit int) ([]pgindex.ValidationTaskDiagnostic, error)
 	ListFederatedReleaseSourceDiagnostics(ctx context.Context, poolID string, limit int) ([]pgindex.FederatedReleaseSourceDiagnostic, error)
+	ListFederationReleaseLedger(ctx context.Context, params pgindex.FederationReleaseLedgerParams) (pgindex.FederationReleaseLedgerPage, error)
 	ListFederatedManifestSourceDiagnostics(ctx context.Context, poolID string, limit int) ([]pgindex.FederatedManifestSourceDiagnostic, error)
 	ListHealthAttestationDiagnostics(ctx context.Context, poolID string, limit int) ([]pgindex.HealthAttestationDiagnostic, error)
 	ListReputationDiagnostics(ctx context.Context, limit int) ([]pgindex.ReputationDiagnostic, error)
@@ -1936,7 +1937,31 @@ func (ctrl *GoNZBNetAdminController) EventDiagnostics(c *echo.Context) error {
 	if !ok {
 		return jsonError(c, http.StatusServiceUnavailable, "gonzbnet admin store is unavailable")
 	}
-	items, err := store.ListFederationEventDiagnostics(c.Request().Context(), parseIntDefault(queryParamTrimmed(c, "limit"), 100))
+	var projected *bool
+	if raw := queryParamTrimmed(c, "projected"); raw != "" {
+		value, parseErr := strconv.ParseBool(raw)
+		if parseErr != nil {
+			return jsonError(c, http.StatusBadRequest, "projected must be true or false")
+		}
+		projected = &value
+	}
+	var tombstoned *bool
+	if raw := queryParamTrimmed(c, "tombstoned"); raw != "" {
+		value, parseErr := strconv.ParseBool(raw)
+		if parseErr != nil {
+			return jsonError(c, http.StatusBadRequest, "tombstoned must be true or false")
+		}
+		tombstoned = &value
+	}
+	items, err := store.ListFederationEventDiagnostics(c.Request().Context(), pgindex.FederationEventDiagnosticParams{
+		PoolID:           queryParamTrimmed(c, "pool_id"),
+		NodeID:           queryParamTrimmed(c, "node_id"),
+		EventType:        queryParamTrimmed(c, "event_type"),
+		ValidationStatus: queryParamTrimmed(c, "validation_status"),
+		Projected:        projected,
+		Tombstoned:       tombstoned,
+		Limit:            parseIntDefault(queryParamTrimmed(c, "limit"), 100),
+	})
 	if err != nil {
 		return jsonError(c, http.StatusInternalServerError, err.Error())
 	}
@@ -2009,6 +2034,28 @@ func (ctrl *GoNZBNetAdminController) ReleaseSourceDiagnostics(c *echo.Context) e
 		return jsonError(c, http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, map[string]any{"items": items, "count": len(items)})
+}
+
+func (ctrl *GoNZBNetAdminController) ReleaseLedger(c *echo.Context) error {
+	store, ok := ctrl.store()
+	if !ok {
+		return jsonError(c, http.StatusServiceUnavailable, "gonzbnet admin store is unavailable")
+	}
+	page, err := store.ListFederationReleaseLedger(c.Request().Context(), pgindex.FederationReleaseLedgerParams{
+		PoolID:    queryParamTrimmed(c, "pool_id"),
+		NodeID:    queryParamTrimmed(c, "node_id"),
+		ReleaseID: queryParamTrimmed(c, "release_id"),
+		State:     queryParamTrimmed(c, "state"),
+		Cursor:    queryParamTrimmed(c, "cursor"),
+		Limit:     parseIntDefault(queryParamTrimmed(c, "limit"), 100),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "invalid release ledger cursor") {
+			return jsonError(c, http.StatusBadRequest, err.Error())
+		}
+		return jsonError(c, http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, page)
 }
 
 func (ctrl *GoNZBNetAdminController) ManifestSourceDiagnostics(c *echo.Context) error {

--- a/internal/api/controllers/gonzbnet_admin_test.go
+++ b/internal/api/controllers/gonzbnet_admin_test.go
@@ -779,6 +779,43 @@ func TestGoNZBNetAdminArticleAvailabilityDiagnostics(t *testing.T) {
 	}
 }
 
+func TestGoNZBNetAdminEventDiagnosticsFilters(t *testing.T) {
+	store := &fakeGoNZBNetAdminStore{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/gonzbnet/diagnostics/events?pool_id=pool.remote&node_id=node.remote&event_type=ReleaseCard&validation_status=accepted&projected=false&tombstoned=true&limit=25", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	ctrl := &GoNZBNetAdminController{appCtx: &app.Context{Config: testGoNZBNetAdminConfig(t)}, storeOverride: store}
+
+	if err := ctrl.EventDiagnostics(c); err != nil {
+		t.Fatalf("EventDiagnostics returned error: %v", err)
+	}
+	params := store.eventDiagnosticParams
+	if rec.Code != http.StatusOK || params.PoolID != "pool.remote" || params.NodeID != "node.remote" || params.EventType != "ReleaseCard" || params.ValidationStatus != "accepted" || params.Limit != 25 {
+		t.Fatalf("unexpected event diagnostic params: %+v status=%d", params, rec.Code)
+	}
+	if params.Projected == nil || *params.Projected || params.Tombstoned == nil || !*params.Tombstoned {
+		t.Fatalf("unexpected boolean event filters: %+v", params)
+	}
+}
+
+func TestGoNZBNetAdminReleaseLedgerFilters(t *testing.T) {
+	store := &fakeGoNZBNetAdminStore{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/gonzbnet/diagnostics/releases?pool_id=pool.remote&node_id=node.remote&release_id=rel_1&state=tombstoned&cursor=cursor_1&limit=20", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	ctrl := &GoNZBNetAdminController{appCtx: &app.Context{Config: testGoNZBNetAdminConfig(t)}, storeOverride: store}
+
+	if err := ctrl.ReleaseLedger(c); err != nil {
+		t.Fatalf("ReleaseLedger returned error: %v", err)
+	}
+	params := store.releaseLedgerParams
+	if rec.Code != http.StatusOK || params.PoolID != "pool.remote" || params.NodeID != "node.remote" || params.ReleaseID != "rel_1" || params.State != "tombstoned" || params.Cursor != "cursor_1" || params.Limit != 20 {
+		t.Fatalf("unexpected release ledger params: %+v status=%d", params, rec.Code)
+	}
+}
+
 const encryptedKeyEnvelopeMarker = "gonzbnet.ed25519.private.v1"
 
 func testGoNZBNetAdminConfig(t *testing.T) *config.Config {
@@ -851,6 +888,8 @@ type fakeGoNZBNetAdminStore struct {
 	activePoolIDs          []string
 	poolHealth             pgindex.FederationPoolHealthReport
 	articleAvailability    []pgindex.ArticleAvailabilityDiagnostic
+	eventDiagnosticParams  pgindex.FederationEventDiagnosticParams
+	releaseLedgerParams    pgindex.FederationReleaseLedgerParams
 }
 
 func (s *fakeGoNZBNetAdminStore) ListFederationActivityRollups(context.Context, pgindex.FederationActivityQuery) ([]activity.Rollup, error) {
@@ -1067,7 +1106,8 @@ func (s *fakeGoNZBNetAdminStore) ListFederationPeerDiagnostics(context.Context, 
 	return nil, nil
 }
 
-func (s *fakeGoNZBNetAdminStore) ListFederationEventDiagnostics(context.Context, int) ([]pgindex.FederationEventDiagnostic, error) {
+func (s *fakeGoNZBNetAdminStore) ListFederationEventDiagnostics(_ context.Context, params pgindex.FederationEventDiagnosticParams) ([]pgindex.FederationEventDiagnostic, error) {
+	s.eventDiagnosticParams = params
 	return nil, nil
 }
 
@@ -1089,6 +1129,11 @@ func (s *fakeGoNZBNetAdminStore) ListValidationTaskDiagnostics(context.Context, 
 
 func (s *fakeGoNZBNetAdminStore) ListFederatedReleaseSourceDiagnostics(context.Context, string, int) ([]pgindex.FederatedReleaseSourceDiagnostic, error) {
 	return nil, nil
+}
+
+func (s *fakeGoNZBNetAdminStore) ListFederationReleaseLedger(_ context.Context, params pgindex.FederationReleaseLedgerParams) (pgindex.FederationReleaseLedgerPage, error) {
+	s.releaseLedgerParams = params
+	return pgindex.FederationReleaseLedgerPage{}, nil
 }
 
 func (s *fakeGoNZBNetAdminStore) ListFederatedManifestSourceDiagnostics(context.Context, string, int) ([]pgindex.FederatedManifestSourceDiagnostic, error) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -284,6 +284,7 @@ func RegisterRoutes(e *echo.Echo, appCtx *app.Context) {
 		v1AdminGoNZBNet.GET("/diagnostics/validation-tasks", gonzbnetAdminCtrl.ValidationTaskDiagnostics)
 		v1AdminGoNZBNet.GET("/diagnostics/binary-evidence", gonzbnetAdminCtrl.BinaryEvidenceDiagnostics)
 		v1AdminGoNZBNet.GET("/diagnostics/release-sources", gonzbnetAdminCtrl.ReleaseSourceDiagnostics)
+		v1AdminGoNZBNet.GET("/diagnostics/releases", gonzbnetAdminCtrl.ReleaseLedger)
 		v1AdminGoNZBNet.GET("/diagnostics/manifest-sources", gonzbnetAdminCtrl.ManifestSourceDiagnostics)
 		v1AdminGoNZBNet.GET("/diagnostics/article-availability", gonzbnetAdminCtrl.ArticleAvailabilityDiagnostics)
 		v1AdminGoNZBNet.GET("/diagnostics/health", gonzbnetAdminCtrl.HealthDiagnostics)

--- a/internal/gonzbnet/manifest/manifest.go
+++ b/internal/gonzbnet/manifest/manifest.go
@@ -53,6 +53,35 @@ type Response struct {
 	ManifestEvent *events.SignedEvent `json:"manifest_event,omitempty"`
 }
 
+func ValidateRequest(in Request, now time.Time, futureTolerance time.Duration) error {
+	if strings.TrimSpace(in.SchemaVersion) != "1.0" || strings.TrimSpace(in.Type) != "ManifestRequest" {
+		return fmt.Errorf("unsupported manifest request schema or type")
+	}
+	if strings.TrimSpace(in.RequestID) == "" || len(in.RequestID) > 256 {
+		return fmt.Errorf("request_id is required and must not exceed 256 bytes")
+	}
+	if strings.TrimSpace(in.ManifestID) == "" || strings.TrimSpace(in.ReleaseID) == "" || strings.TrimSpace(in.PoolID) == "" || strings.TrimSpace(in.RequestingNodeID) == "" {
+		return fmt.Errorf("manifest_id, release_id, pool_id, and requesting_node_id are required")
+	}
+	if len(in.Reason) > 256 {
+		return fmt.Errorf("reason exceeds field limit")
+	}
+	createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(in.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("created_at must be RFC3339")
+	}
+	if futureTolerance <= 0 {
+		futureTolerance = 2 * time.Minute
+	}
+	if !now.IsZero() {
+		delta := now.UTC().Sub(createdAt.UTC())
+		if delta > futureTolerance || delta < -futureTolerance {
+			return fmt.Errorf("created_at is outside request tolerance")
+		}
+	}
+	return nil
+}
+
 type ManifestCore struct {
 	Groups          []string       `json:"groups"`
 	Poster          string         `json:"poster,omitempty"`

--- a/internal/gonzbnet/manifest/manifest_test.go
+++ b/internal/gonzbnet/manifest/manifest_test.go
@@ -4,7 +4,39 @@ import (
 	"encoding/xml"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestValidateRequestRejectsMissingAndStaleBindings(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	valid := Request{
+		SchemaVersion: "1.0", Type: "ManifestRequest", RequestID: "req_1",
+		ManifestID: "man_1", ReleaseID: "rel_1", PoolID: "pool_1",
+		RequestingNodeID: "node_1", Reason: "user_get", CreatedAt: now.Format(time.RFC3339),
+	}
+	if err := ValidateRequest(valid, now, 2*time.Minute); err != nil {
+		t.Fatalf("validate request: %v", err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*Request)
+	}{
+		{name: "missing release", mutate: func(in *Request) { in.ReleaseID = "" }},
+		{name: "missing pool", mutate: func(in *Request) { in.PoolID = "" }},
+		{name: "wrong type", mutate: func(in *Request) { in.Type = "OtherRequest" }},
+		{name: "stale timestamp", mutate: func(in *Request) { in.CreatedAt = now.Add(-3 * time.Minute).Format(time.RFC3339) }},
+		{name: "future timestamp", mutate: func(in *Request) { in.CreatedAt = now.Add(3 * time.Minute).Format(time.RFC3339) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := valid
+			tt.mutate(&item)
+			if err := ValidateRequest(item, now, 2*time.Minute); err == nil {
+				t.Fatal("expected request validation failure")
+			}
+		})
+	}
+}
 
 func TestValidateManifestIDAndRejectTamper(t *testing.T) {
 	item := testManifest(t)

--- a/internal/gonzbnet/manifestresolver/resolver.go
+++ b/internal/gonzbnet/manifestresolver/resolver.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/datallboy/gonzb/internal/gonzbnet/activity"
 	"github.com/datallboy/gonzb/internal/gonzbnet/canonical"
+	"github.com/datallboy/gonzb/internal/gonzbnet/eventbody"
 	"github.com/datallboy/gonzb/internal/gonzbnet/events"
 	"github.com/datallboy/gonzb/internal/gonzbnet/manifest"
 	gonzbnetmetrics "github.com/datallboy/gonzb/internal/gonzbnet/metrics"
@@ -29,6 +30,7 @@ type Identity interface {
 type Store interface {
 	GetCachedFederatedNZBByReleaseID(ctx context.Context, releaseID string) ([]byte, bool, error)
 	FindFederatedManifestSource(ctx context.Context, releaseID string) (*pgindex.FederatedManifestSource, error)
+	AuthorizeFederatedManifestSource(ctx context.Context, source pgindex.FederatedManifestSource, authorNodeID string) error
 	AppendVerifiedFederationEvent(ctx context.Context, event *events.SignedEvent, validation *events.ValidationResult) error
 	StoreResolutionManifest(ctx context.Context, record pgindex.ResolutionManifestRecord) error
 	RecordFederatedManifestSourceSuccess(ctx context.Context, source pgindex.FederatedManifestSource) error
@@ -123,6 +125,9 @@ func (r *Resolver) ResolveNZB(ctx context.Context, releaseID string) (reader io.
 	if source == nil {
 		return nil, fmt.Errorf("federated manifest source not found")
 	}
+	if err := r.store.AuthorizeFederatedManifestSource(ctx, *source, ""); err != nil {
+		return nil, err
+	}
 	failSource := func(err error) (io.ReadCloser, error) {
 		_ = r.store.RecordFederatedManifestSourceFailure(ctx, *source)
 		return nil, err
@@ -141,6 +146,15 @@ func (r *Resolver) ResolveNZB(ctx context.Context, releaseID string) (reader io.
 	if event.EventType != manifest.Type {
 		return failSource(fmt.Errorf("unexpected manifest event type %q", event.EventType))
 	}
+	if err := eventbody.Validate(event, time.Now().UTC(), r.eventTimeTolerance); err != nil {
+		return failSource(fmt.Errorf("invalid manifest event body: %w", err))
+	}
+	if event.BodySchema != manifest.BodySchema {
+		return failSource(fmt.Errorf("unexpected manifest body schema %q", event.BodySchema))
+	}
+	if len(event.PoolIDs) != 1 || strings.TrimSpace(event.PoolIDs[0]) != strings.TrimSpace(source.PoolID) {
+		return failSource(fmt.Errorf("manifest event pool mismatch"))
+	}
 	var body manifest.ResolutionManifest
 	if err := json.Unmarshal(event.Body, &body); err != nil {
 		return failSource(err)
@@ -152,6 +166,12 @@ func (r *Resolver) ResolveNZB(ctx context.Context, releaseID string) (reader io.
 	if body.ManifestID != source.ManifestID {
 		return failSource(fmt.Errorf("manifest_id mismatch"))
 	}
+	if body.ReleaseID != releaseID || body.ReleaseID != source.ReleaseID {
+		return failSource(fmt.Errorf("release_id mismatch"))
+	}
+	if err := r.store.AuthorizeFederatedManifestSource(ctx, *source, event.AuthorNodeID); err != nil {
+		return failSource(err)
+	}
 	nzbPayload, err := manifest.GenerateNZB(body)
 	if err != nil {
 		return failSource(err)
@@ -162,6 +182,7 @@ func (r *Resolver) ResolveNZB(ctx context.Context, releaseID string) (reader io.
 	if err := r.store.StoreResolutionManifest(ctx, pgindex.ResolutionManifestRecord{
 		Manifest:              body,
 		SourceNodeID:          event.AuthorNodeID,
+		FetchedFromNodeID:     source.SourceNodeID,
 		SourceEventID:         event.EventID,
 		PoolID:                source.PoolID,
 		CanonicalManifestJSON: canonicalCore,
@@ -234,6 +255,12 @@ func (r *Resolver) fetchManifest(ctx context.Context, source pgindex.FederatedMa
 	}
 	if err := json.Unmarshal(payload, &out); err != nil {
 		return nil, err
+	}
+	if out.SchemaVersion != "1.0" || out.Type != "ManifestResponse" {
+		return nil, fmt.Errorf("invalid manifest response schema or type")
+	}
+	if strings.TrimSpace(out.RequestID) != requestID {
+		return nil, fmt.Errorf("manifest response request_id mismatch")
 	}
 	if out.Status != "ok" || out.ManifestEvent == nil {
 		return nil, fmt.Errorf("manifest response error: %s", firstNonBlank(out.Message, out.Code, "missing manifest_event"))

--- a/internal/gonzbnet/manifestresolver/resolver_test.go
+++ b/internal/gonzbnet/manifestresolver/resolver_test.go
@@ -39,10 +39,12 @@ func TestResolveNZBFetchesSignedManifestWithoutUserContext(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
+		var request manifest.Request
+		_ = json.Unmarshal(body, &request)
 		_ = json.NewEncoder(w).Encode(manifest.Response{
 			SchemaVersion: "1.0",
 			Type:          "ManifestResponse",
-			RequestID:     "req_test",
+			RequestID:     request.RequestID,
 			Status:        "ok",
 			ManifestEvent: manifestEvent,
 		})
@@ -122,10 +124,12 @@ func TestResolveNZBRejectsExpiredManifestEvent(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
+		var request manifest.Request
+		_ = json.Unmarshal(body, &request)
 		_ = json.NewEncoder(w).Encode(manifest.Response{
 			SchemaVersion: "1.0",
 			Type:          "ManifestResponse",
-			RequestID:     "req_test",
+			RequestID:     request.RequestID,
 			Status:        "ok",
 			ManifestEvent: manifestEvent,
 		})
@@ -205,11 +209,89 @@ func TestResolveNZBRejectsOversizedManifestResponse(t *testing.T) {
 	}
 }
 
+func TestResolveNZBRejectsTamperedResponseBindings(t *testing.T) {
+	tests := []struct {
+		name              string
+		eventReleaseID    string
+		eventPoolID       string
+		mismatchedRequest bool
+		wantError         string
+	}{
+		{name: "response request", eventReleaseID: "rel_1", eventPoolID: "pool.local", mismatchedRequest: true, wantError: "request_id mismatch"},
+		{name: "release", eventReleaseID: "rel_other", eventPoolID: "pool.local", wantError: "release_id mismatch"},
+		{name: "pool", eventReleaseID: "rel_1", eventPoolID: "pool.other", wantError: "pool mismatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			localIdentity, err := identity.LoadOrCreate(t.TempDir())
+			if err != nil {
+				t.Fatalf("local identity: %v", err)
+			}
+			localNodeID, _ := localIdentity.NodeID(ctx)
+			localPublicKey, _ := localIdentity.PublicKey(ctx)
+			_, manifestEvent := testManifestEventFor(t, tt.eventReleaseID, tt.eventPoolID)
+			requestStore := &fakeRequestStore{
+				keys:   map[string]ed25519.PublicKey{localNodeID: localPublicKey},
+				nonces: map[string]bool{},
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestBody, _ := io.ReadAll(r.Body)
+				if _, err := requestauth.Verify(ctx, requestStore, r.Header.Get("Authorization"), r.Method, r.URL.Path, r.URL.RawQuery, requestBody, time.Now(), 2*time.Minute, 10*time.Minute); err != nil {
+					http.Error(w, err.Error(), http.StatusUnauthorized)
+					return
+				}
+				var request manifest.Request
+				_ = json.Unmarshal(requestBody, &request)
+				responseRequestID := request.RequestID
+				if tt.mismatchedRequest {
+					responseRequestID = "req_wrong"
+				}
+				_ = json.NewEncoder(w).Encode(manifest.Response{
+					SchemaVersion: "1.0",
+					Type:          "ManifestResponse",
+					RequestID:     responseRequestID,
+					Status:        "ok",
+					ManifestEvent: manifestEvent,
+				})
+			}))
+			defer server.Close()
+
+			var body manifest.ResolutionManifest
+			if err := json.Unmarshal(manifestEvent.Body, &body); err != nil {
+				t.Fatalf("manifest body: %v", err)
+			}
+			store := &fakeResolverStore{source: &pgindex.FederatedManifestSource{
+				ManifestID: body.ManifestID, ReleaseID: "rel_1", SourceNodeID: manifestEvent.AuthorNodeID,
+				PoolID: "pool.local", BaseURL: server.URL, TrustScore: 1,
+			}}
+			_, err = NewWithOptions(localIdentity, store, Options{AllowInsecurePeerHTTP: true}).ResolveNZB(ctx, "rel_1")
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("expected %q rejection, got %v", tt.wantError, err)
+			}
+			if store.stored != nil {
+				t.Fatal("tampered manifest response should not be cached")
+			}
+			if store.failures != 1 {
+				t.Fatalf("expected source failure to be recorded, got %d", store.failures)
+			}
+		})
+	}
+}
+
 func testManifestEvent(t *testing.T) (*identity.Identity, *events.SignedEvent) {
-	return testManifestEventWithTimes(t, time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC), nil)
+	return testManifestEventFor(t, "rel_1", "pool.local")
+}
+
+func testManifestEventFor(t *testing.T, releaseID, poolID string) (*identity.Identity, *events.SignedEvent) {
+	return testManifestEventWithOptions(t, releaseID, poolID, time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC), nil)
 }
 
 func testManifestEventWithTimes(t *testing.T, createdAt time.Time, expiresAt *time.Time) (*identity.Identity, *events.SignedEvent) {
+	return testManifestEventWithOptions(t, "rel_1", "pool.local", createdAt, expiresAt)
+}
+
+func testManifestEventWithOptions(t *testing.T, releaseID, poolID string, createdAt time.Time, expiresAt *time.Time) (*identity.Identity, *events.SignedEvent) {
 	t.Helper()
 	node, err := identity.LoadOrCreate(t.TempDir())
 	if err != nil {
@@ -236,7 +318,7 @@ func testManifestEventWithTimes(t *testing.T, createdAt time.Time, expiresAt *ti
 		SchemaVersion: "1.0",
 		Type:          manifest.Type,
 		ManifestID:    manifestID,
-		ReleaseID:     "rel_1",
+		ReleaseID:     releaseID,
 		ManifestCore:  core,
 	}
 	event, validation, err := events.Create(context.Background(), node, events.CreateOptions{
@@ -244,7 +326,7 @@ func testManifestEventWithTimes(t *testing.T, createdAt time.Time, expiresAt *ti
 		Sequence:   1,
 		CreatedAt:  createdAt,
 		ExpiresAt:  expiresAt,
-		PoolIDs:    []string{"pool.local"},
+		PoolIDs:    []string{poolID},
 		Visibility: "pool",
 		BodySchema: manifest.BodySchema,
 		Body:       body,
@@ -270,6 +352,10 @@ func (s *fakeResolverStore) GetCachedFederatedNZBByReleaseID(context.Context, st
 
 func (s *fakeResolverStore) FindFederatedManifestSource(context.Context, string) (*pgindex.FederatedManifestSource, error) {
 	return s.source, nil
+}
+
+func (s *fakeResolverStore) AuthorizeFederatedManifestSource(context.Context, pgindex.FederatedManifestSource, string) error {
+	return nil
 }
 
 func (s *fakeResolverStore) AppendVerifiedFederationEvent(context.Context, *events.SignedEvent, *events.ValidationResult) error {

--- a/internal/gonzbnet/metrics/metrics.go
+++ b/internal/gonzbnet/metrics/metrics.go
@@ -16,6 +16,7 @@ const (
 	PeerFailuresTotal                   = "gonzbnet_peer_failures_total"
 	ManifestRequestsTotal               = "gonzbnet_manifest_requests_total"
 	ManifestRequestFailuresTotal        = "gonzbnet_manifest_request_failures_total"
+	ManifestCacheIntegrityFailuresTotal = "gonzbnet_manifest_cache_integrity_failures_total"
 	BinaryEvidencePeerRequestsTotal     = "gonzbnet_binary_evidence_peer_requests_total"
 	BinaryEvidencePeerFailuresTotal     = "gonzbnet_binary_evidence_peer_failures_total"
 	BinaryEvidenceYEncHitsTotal         = "gonzbnet_binary_evidence_yenc_hits_total"
@@ -40,6 +41,7 @@ var counterNames = []string{
 	PeerFailuresTotal,
 	ManifestRequestsTotal,
 	ManifestRequestFailuresTotal,
+	ManifestCacheIntegrityFailuresTotal,
 	ReleaseCardsProjectedTotal,
 	HealthAttestationsTotal,
 	BinaryEvidencePeerRequestsTotal,

--- a/internal/store/pgindex/federation_diagnostics_store.go
+++ b/internal/store/pgindex/federation_diagnostics_store.go
@@ -2,6 +2,8 @@ package pgindex
 
 import (
 	"context"
+	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -38,6 +40,17 @@ type FederationEventDiagnostic struct {
 	RejectionReason  string          `json:"rejection_reason,omitempty"`
 	Projected        bool            `json:"projected"`
 	ProjectedAt      *time.Time      `json:"projected_at,omitempty"`
+	Tombstoned       bool            `json:"tombstoned"`
+}
+
+type FederationEventDiagnosticParams struct {
+	PoolID           string
+	NodeID           string
+	EventType        string
+	ValidationStatus string
+	Projected        *bool
+	Tombstoned       *bool
+	Limit            int
 }
 
 type FederationRejectedEventDiagnostic struct {
@@ -119,6 +132,54 @@ type FederatedManifestSourceDiagnostic struct {
 	AvgLatencyMS  int        `json:"avg_latency_ms"`
 	TrustScore    float64    `json:"trust_score"`
 	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+type FederationReleaseLedgerParams struct {
+	PoolID    string
+	NodeID    string
+	ReleaseID string
+	State     string
+	Cursor    string
+	Limit     int
+}
+
+type FederationReleaseLedgerItem struct {
+	ReleaseID               string     `json:"release_id"`
+	ManifestID              string     `json:"manifest_id"`
+	ProjectedTitle          string     `json:"projected_title"`
+	SignedTitle             string     `json:"signed_title"`
+	ProjectionMatchesSigned bool       `json:"projection_matches_signed_event"`
+	SourceNodeID            string     `json:"source_node_id"`
+	SourceEventID           string     `json:"source_event_id"`
+	SourceBodyHash          string     `json:"source_body_hash"`
+	PoolID                  string     `json:"pool_id"`
+	NodeStatus              string     `json:"node_status"`
+	MembershipStatus        string     `json:"membership_status"`
+	PublicationState        string     `json:"publication_state"`
+	PublicationEventID      string     `json:"publication_event_id,omitempty"`
+	PublicationReason       string     `json:"publication_reason,omitempty"`
+	PublicationChangedAt    *time.Time `json:"publication_changed_at,omitempty"`
+	TombstoneTargetType     string     `json:"tombstone_target_type,omitempty"`
+	TombstoneTargetID       string     `json:"tombstone_target_id,omitempty"`
+	TombstoneSeverity       string     `json:"tombstone_severity,omitempty"`
+	TombstoneSourceEventID  string     `json:"tombstone_source_event_id,omitempty"`
+	EffectiveState          string     `json:"effective_state"`
+	PostedAt                *time.Time `json:"posted_at,omitempty"`
+	FirstSeenAt             time.Time  `json:"first_seen_at"`
+	LastSeenAt              time.Time  `json:"last_seen_at"`
+}
+
+type FederationReleaseLedgerPage struct {
+	Items      []FederationReleaseLedgerItem `json:"items"`
+	Count      int                           `json:"count"`
+	NextCursor string                        `json:"next_cursor,omitempty"`
+}
+
+type federationReleaseLedgerCursor struct {
+	LastSeenAt   time.Time `json:"last_seen_at"`
+	ReleaseID    string    `json:"release_id"`
+	SourceNodeID string    `json:"source_node_id"`
+	PoolID       string    `json:"pool_id"`
 }
 
 type HealthAttestationDiagnostic struct {
@@ -207,18 +268,67 @@ func (s *Store) ListFederationPeerDiagnostics(ctx context.Context, limit int) ([
 	return out, rows.Err()
 }
 
-func (s *Store) ListFederationEventDiagnostics(ctx context.Context, limit int) ([]FederationEventDiagnostic, error) {
+func (s *Store) ListFederationEventDiagnostics(ctx context.Context, params FederationEventDiagnosticParams) ([]FederationEventDiagnostic, error) {
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("pgindex store is not initialized")
 	}
-	limit = clampDiagnosticsLimit(limit, 100)
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT event_id, event_type, author_node_id, sequence, body_hash,
-		       pool_ids, visibility, created_at, received_at, validation_status,
-		       COALESCE(rejection_reason, ''), projected, projected_at
-		FROM federation_events
+	limit := clampDiagnosticsLimit(params.Limit, 100)
+	clauses := []string{"1=1"}
+	args := []any{}
+	arg := 1
+	addEqual := func(column, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			clauses = append(clauses, fmt.Sprintf("%s = $%d", column, arg))
+			args = append(args, value)
+			arg++
+		}
+	}
+	addEqual("e.author_node_id", params.NodeID)
+	addEqual("e.event_type", params.EventType)
+	addEqual("e.validation_status", params.ValidationStatus)
+	if poolID := strings.TrimSpace(params.PoolID); poolID != "" {
+		clauses = append(clauses, fmt.Sprintf("e.pool_ids @> jsonb_build_array($%d::text)", arg))
+		args = append(args, poolID)
+		arg++
+	}
+	if params.Projected != nil {
+		clauses = append(clauses, fmt.Sprintf("e.projected = $%d", arg))
+		args = append(args, *params.Projected)
+		arg++
+	}
+	if params.Tombstoned != nil {
+		clauses = append(clauses, fmt.Sprintf(`EXISTS (
+		  SELECT 1 FROM tombstones filter_tombstone
+		  WHERE filter_tombstone.active = TRUE
+		    AND filter_tombstone.target_type = 'event'
+		    AND filter_tombstone.target_id = e.event_id
+		    AND filter_tombstone.severity IN ('hide','reject','local_only')
+		    AND filter_tombstone.effective_at <= NOW()
+		    AND (filter_tombstone.expires_at IS NULL OR filter_tombstone.expires_at > NOW())
+		    AND (filter_tombstone.pool_id IS NULL OR e.pool_ids @> jsonb_build_array(filter_tombstone.pool_id))
+		) = $%d`, arg))
+		args = append(args, *params.Tombstoned)
+		arg++
+	}
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT e.event_id, e.event_type, e.author_node_id, e.sequence, e.body_hash,
+		       e.pool_ids, e.visibility, e.created_at, e.received_at, e.validation_status,
+		       COALESCE(e.rejection_reason, ''), e.projected, e.projected_at,
+		       EXISTS (
+		         SELECT 1 FROM tombstones t
+		         WHERE t.active = TRUE
+		           AND t.target_type = 'event'
+		           AND t.target_id = e.event_id
+		           AND t.severity IN ('hide','reject','local_only')
+		           AND t.effective_at <= NOW()
+		           AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		           AND (t.pool_id IS NULL OR e.pool_ids @> jsonb_build_array(t.pool_id))
+		       )
+		FROM federation_events e
+		WHERE %s
 		ORDER BY received_at DESC, event_id DESC
-		LIMIT $1`, limit)
+		LIMIT $%d`, strings.Join(clauses, " AND "), arg), args...)
 	if err != nil {
 		return nil, fmt.Errorf("list federation event diagnostics: %w", err)
 	}
@@ -228,7 +338,7 @@ func (s *Store) ListFederationEventDiagnostics(ctx context.Context, limit int) (
 		var item FederationEventDiagnostic
 		var poolIDs []byte
 		var projectedAt nullableTime
-		if err := rows.Scan(&item.EventID, &item.EventType, &item.AuthorNodeID, &item.Sequence, &item.BodyHash, &poolIDs, &item.Visibility, &item.CreatedAt, &item.ReceivedAt, &item.ValidationStatus, &item.RejectionReason, &item.Projected, &projectedAt); err != nil {
+		if err := rows.Scan(&item.EventID, &item.EventType, &item.AuthorNodeID, &item.Sequence, &item.BodyHash, &poolIDs, &item.Visibility, &item.CreatedAt, &item.ReceivedAt, &item.ValidationStatus, &item.RejectionReason, &item.Projected, &projectedAt, &item.Tombstoned); err != nil {
 			return nil, err
 		}
 		item.PoolIDs = defaultRawJSON(poolIDs, `[]`)
@@ -399,6 +509,219 @@ func (s *Store) ListFederatedReleaseSourceDiagnostics(ctx context.Context, poolI
 		out = append(out, item)
 	}
 	return out, rows.Err()
+}
+
+func (s *Store) ListFederationReleaseLedger(ctx context.Context, params FederationReleaseLedgerParams) (FederationReleaseLedgerPage, error) {
+	var page FederationReleaseLedgerPage
+	if s == nil || s.db == nil {
+		return page, fmt.Errorf("pgindex store is not initialized")
+	}
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	arg := 1
+	addEqual := func(column, value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", column, arg))
+		args = append(args, value)
+		arg++
+	}
+	addEqual("source.pool_id", params.PoolID)
+	addEqual("source.source_node_id", params.NodeID)
+	addEqual("source.release_id", params.ReleaseID)
+
+	if strings.TrimSpace(params.Cursor) != "" {
+		cursor, err := decodeFederationReleaseLedgerCursor(params.Cursor)
+		if err != nil {
+			return page, err
+		}
+		clauses = append(clauses, fmt.Sprintf(`
+			(source.last_seen_at, source.release_id, source.source_node_id, source.pool_id)
+			< ($%d, $%d, $%d, $%d)`, arg, arg+1, arg+2, arg+3))
+		args = append(args, cursor.LastSeenAt, cursor.ReleaseID, cursor.SourceNodeID, cursor.PoolID)
+		arg += 4
+	}
+	stateClause := ""
+	if state := strings.TrimSpace(params.State); state != "" {
+		stateClause = fmt.Sprintf("WHERE effective_state = $%d", arg)
+		args = append(args, state)
+		arg++
+	}
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		WITH ledger_base AS (
+		  SELECT
+		    source.release_id AS release_id,
+		    COALESCE(source.manifest_id, '') AS manifest_id,
+		    card.title AS projected_title,
+		    COALESCE(event.body_json->>'title', '') AS signed_title,
+		    event.event_id IS NOT NULL
+		      AND event.validation_status = 'accepted'
+		      AND event.event_type = 'ReleaseCard'
+		      AND card.body_json = event.body_json
+		      AND COALESCE(event.body_json->>'release_id', '') = source.release_id
+		      AND COALESCE(event.body_json->>'manifest_id', '') = COALESCE(source.manifest_id, '')
+		      AND card.title = COALESCE(event.body_json->>'title', '')
+		      AND card.normalized_title = COALESCE(event.body_json->>'normalized_title', '')
+		      AND card.category_json = COALESCE(event.body_json->'category', '[]'::jsonb)
+		      AND card.newznab_categories = COALESCE(event.body_json->'newznab_categories', '[]'::jsonb)
+		      AND card.size_bytes IS NOT DISTINCT FROM NULLIF(event.body_json->>'size_bytes', '')::bigint
+		      AND card.posted_at IS NOT DISTINCT FROM NULLIF(event.body_json->>'posted_at', '')::timestamptz
+		      AND card.groups_json = COALESCE(event.body_json->'groups', '[]'::jsonb)
+		      AND card.file_count IS NOT DISTINCT FROM NULLIF(event.body_json->>'file_count', '')::integer
+		      AND card.segment_count IS NOT DISTINCT FROM NULLIF(event.body_json->>'segment_count', '')::integer
+		      AND COALESCE(card.poster_hash, '') = COALESCE(event.body_json->>'poster_hash', '')
+		      AND card.subject_fingerprint = COALESCE(event.body_json->>'subject_fingerprint', '')
+		      AND card.file_fingerprint = COALESCE(event.body_json->>'file_fingerprint', '')
+		      AND card.media_json = COALESCE(event.body_json->'media', '{}'::jsonb)
+		      AND card.quality_json = COALESCE(event.body_json->'quality', '{}'::jsonb)
+		      AND card.flags_json = COALESCE(event.body_json->'flags', '{}'::jsonb)
+		      AND card.resolution_json = COALESCE(event.body_json->'resolution', '{}'::jsonb)
+		      AND card.expires_at IS NOT DISTINCT FROM NULLIF(event.body_json->>'expires_at', '')::timestamptz AS projection_matches,
+		    source.source_node_id AS source_node_id,
+		    source.source_event_id AS source_event_id,
+		    COALESCE(event.body_hash, '') AS body_hash,
+		    source.pool_id AS pool_id,
+		    COALESCE(node.status, 'unknown') AS node_status,
+		    COALESCE(member.membership_status, 'missing') AS membership_status,
+		    COALESCE(publication.state, 'active') AS publication_state,
+		    COALESCE(publication.source_event_id, '') AS publication_event_id,
+		    COALESCE(publication.reason, '') AS publication_reason,
+		    publication.effective_at AS publication_changed_at,
+		    COALESCE(tomb.target_type, '') AS tombstone_target_type,
+		    COALESCE(tomb.target_id, '') AS tombstone_target_id,
+		    COALESCE(tomb.severity, '') AS tombstone_severity,
+		    COALESCE(tomb.source_event_id, '') AS tombstone_source_event_id,
+		    card.posted_at AS posted_at,
+		    source.first_seen_at AS first_seen_at,
+		    source.last_seen_at AS last_seen_at
+		  FROM federated_release_sources source
+		  JOIN federated_release_cards card ON card.release_id = source.release_id
+		  LEFT JOIN federation_events event ON event.event_id = source.source_event_id
+		  LEFT JOIN federation_nodes node ON node.node_id = source.source_node_id
+		  LEFT JOIN federated_release_publication_states publication
+		    ON publication.release_id = source.release_id
+		   AND publication.source_node_id = source.source_node_id
+		   AND publication.pool_id = source.pool_id
+		  LEFT JOIN LATERAL (
+		    SELECT CASE WHEN BOOL_OR(pm.status = 'active') THEN 'active' ELSE MAX(pm.status) END AS membership_status
+		    FROM pool_members pm
+		    WHERE pm.pool_id = source.pool_id AND pm.node_id = source.source_node_id
+		  ) member ON TRUE
+		  LEFT JOIN LATERAL (
+		    SELECT t.target_type, t.target_id, t.severity, t.source_event_id
+		    FROM tombstones t
+		    WHERE t.active = TRUE
+		      AND t.severity IN ('hide','reject','local_only')
+		      AND t.effective_at <= NOW()
+		      AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		      AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
+		      AND (
+		        (t.target_type = 'release' AND t.target_id = source.release_id)
+		        OR (t.target_type = 'manifest' AND t.target_id = COALESCE(source.manifest_id, ''))
+		        OR (t.target_type = 'event' AND t.target_id = source.source_event_id)
+		        OR (t.target_type = 'node' AND t.target_id = source.source_node_id)
+		        OR (t.target_type = 'pool_member' AND t.target_id = source.source_node_id)
+		      )
+		    ORDER BY CASE t.severity WHEN 'reject' THEN 1 WHEN 'local_only' THEN 2 ELSE 3 END,
+		             t.updated_at DESC
+		    LIMIT 1
+		  ) tomb ON TRUE
+		  WHERE %s
+		),
+		ledger AS (
+		  SELECT ledger_base.*,
+		    CASE
+		      WHEN NOT projection_matches THEN 'projection_mismatch'
+		      WHEN tombstone_target_type <> '' THEN 'tombstoned'
+		      WHEN node_status IN ('blocked', 'forked') THEN 'blocked'
+		      WHEN membership_status <> 'active' THEN 'revoked'
+		      WHEN publication_state = 'withdrawn' THEN 'withdrawn'
+		      ELSE 'active'
+		    END AS effective_state
+		  FROM ledger_base
+		)
+		SELECT release_id, manifest_id, projected_title, signed_title,
+		       projection_matches, source_node_id, source_event_id, body_hash,
+		       pool_id, node_status, membership_status, publication_state,
+		       publication_event_id, publication_reason, publication_changed_at,
+		       tombstone_target_type, tombstone_target_id, tombstone_severity,
+		       tombstone_source_event_id, effective_state, posted_at,
+		       first_seen_at, last_seen_at
+		FROM ledger
+		%s
+		ORDER BY last_seen_at DESC, release_id DESC, source_node_id DESC, pool_id DESC
+		LIMIT $%d`, strings.Join(clauses, " AND "), stateClause, arg), args...)
+	if err != nil {
+		return page, fmt.Errorf("list federation release ledger: %w", err)
+	}
+	defer rows.Close()
+	items := make([]FederationReleaseLedgerItem, 0, limit+1)
+	for rows.Next() {
+		var item FederationReleaseLedgerItem
+		var publicationChangedAt, postedAt sql.NullTime
+		if err := rows.Scan(
+			&item.ReleaseID, &item.ManifestID, &item.ProjectedTitle, &item.SignedTitle,
+			&item.ProjectionMatchesSigned, &item.SourceNodeID, &item.SourceEventID,
+			&item.SourceBodyHash, &item.PoolID, &item.NodeStatus, &item.MembershipStatus,
+			&item.PublicationState, &item.PublicationEventID, &item.PublicationReason,
+			&publicationChangedAt, &item.TombstoneTargetType, &item.TombstoneTargetID,
+			&item.TombstoneSeverity, &item.TombstoneSourceEventID, &item.EffectiveState,
+			&postedAt, &item.FirstSeenAt, &item.LastSeenAt,
+		); err != nil {
+			return page, err
+		}
+		if publicationChangedAt.Valid {
+			value := publicationChangedAt.Time.UTC()
+			item.PublicationChangedAt = &value
+		}
+		if postedAt.Valid {
+			value := postedAt.Time.UTC()
+			item.PostedAt = &value
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return page, err
+	}
+	if len(items) > limit {
+		last := items[limit-1]
+		page.NextCursor = encodeFederationReleaseLedgerCursor(federationReleaseLedgerCursor{
+			LastSeenAt: last.LastSeenAt, ReleaseID: last.ReleaseID,
+			SourceNodeID: last.SourceNodeID, PoolID: last.PoolID,
+		})
+		items = items[:limit]
+	}
+	page.Items = items
+	page.Count = len(items)
+	return page, nil
+}
+
+func decodeFederationReleaseLedgerCursor(raw string) (federationReleaseLedgerCursor, error) {
+	var cursor federationReleaseLedgerCursor
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return cursor, fmt.Errorf("invalid release ledger cursor")
+	}
+	if err := json.Unmarshal(payload, &cursor); err != nil || cursor.LastSeenAt.IsZero() || cursor.ReleaseID == "" || cursor.SourceNodeID == "" || cursor.PoolID == "" {
+		return cursor, fmt.Errorf("invalid release ledger cursor")
+	}
+	return cursor, nil
+}
+
+func encodeFederationReleaseLedgerCursor(cursor federationReleaseLedgerCursor) string {
+	payload, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(payload)
 }
 
 func (s *Store) ListFederatedManifestSourceDiagnostics(ctx context.Context, poolID string, limit int) ([]FederatedManifestSourceDiagnostic, error) {

--- a/internal/store/pgindex/federation_integrity_integration_test.go
+++ b/internal/store/pgindex/federation_integrity_integration_test.go
@@ -1,0 +1,291 @@
+package pgindex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/datallboy/gonzb/internal/gonzbnet/capability"
+	"github.com/datallboy/gonzb/internal/gonzbnet/events"
+	"github.com/datallboy/gonzb/internal/gonzbnet/identity"
+	"github.com/datallboy/gonzb/internal/gonzbnet/manifest"
+	"github.com/datallboy/gonzb/internal/gonzbnet/moderation"
+	"github.com/datallboy/gonzb/internal/gonzbnet/pools"
+	"github.com/datallboy/gonzb/internal/gonzbnet/releasecard"
+)
+
+func TestFederationIntegrityLedgerAndCacheRepairIntegration(t *testing.T) {
+	ctx := context.Background()
+	store := openPostgresTestStore(t)
+	node, err := identity.LoadOrCreate(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeID, _ := node.NodeID(ctx)
+	publicKey, _ := node.PublicKey(ctx)
+	poolID := "pool.integrity"
+	if err := store.UpsertFederationNode(ctx, FederationNodeRecord{
+		NodeID: nodeID, PublicKey: publicKey, BaseURL: "https://integrity.example/gonzbnet/v1", Status: "known",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertTrustPool(ctx, TrustPoolRecord{
+		PoolID: poolID, DisplayName: "Integrity", PolicyJSON: json.RawMessage(`{}`),
+		MembershipThreshold: 1, ModerationThreshold: 1, CheckpointWitnessThreshold: 1,
+		AcceptMode: "pool_member", AcceptedEventTypes: []string{pools.EventTypeReleaseCard, manifest.Type, moderation.Type}, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertPoolMember(ctx, PoolMemberRecord{
+		PoolID: poolID, NodeID: nodeID, Role: pools.RoleAdmin, Status: pools.StatusActive,
+		AllowedCapabilities: []string{capability.ReleasePublisher, capability.ManifestBuilder, capability.Admin},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	postedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	local := releasecard.LocalRelease{
+		LocalReleaseID: "integrity-local", Title: "Integrity Release", SizeBytes: 1000,
+		PostedAt: &postedAt, AddedAt: &postedAt, FileCount: 1,
+		Groups: []string{"alt.binaries.integrity"}, SourceKind: "local_indexer_cache",
+		Files: []releasecard.LocalFile{{
+			Name: "integrity.rar", Subject: "Integrity Release integrity.rar yEnc",
+			Poster: "poster@example.invalid", PostedAt: &postedAt, SizeBytes: 1000,
+			FileIndex: 1, ArticleCount: 1, TotalParts: 1,
+			Segments: []releasecard.LocalSegment{{Number: 1, Bytes: 1000, MessageID: "<integrity@example.invalid>"}},
+		}},
+	}
+	card, err := releasecard.MapLocalRelease(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cardEvent, cardValidation, err := events.Create(ctx, node, events.CreateOptions{
+		EventType: pools.EventTypeReleaseCard, Sequence: 1, CreatedAt: time.Now().UTC(),
+		PoolIDs: []string{poolID}, Visibility: "pool", BodySchema: releasecard.BodySchema, Body: card,
+	})
+	if err != nil || cardValidation == nil || !cardValidation.OK {
+		t.Fatalf("create card event: validation=%+v err=%v", cardValidation, err)
+	}
+	if err := store.AppendVerifiedFederationEventWithProjection(ctx, cardEvent, cardValidation, func(projectCtx context.Context) error {
+		return store.UpsertFederatedReleaseCardProjection(projectCtx, releasecard.Projection{
+			Card: card, EventID: cardEvent.EventID, SourceNodeID: nodeID, PoolID: poolID,
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := store.ListFederationReleaseLedger(ctx, FederationReleaseLedgerParams{PoolID: poolID, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].EffectiveState != "active" || !page.Items[0].ProjectionMatchesSigned {
+		t.Fatalf("unexpected active ledger: %+v", page)
+	}
+	searchItems, err := store.SearchFederatedReleaseCards(ctx, FederatedReleaseCardSearchParams{Pools: []string{poolID}, Limit: 10})
+	if err != nil || len(searchItems) != 1 || searchItems[0].ReleaseID != card.ReleaseID {
+		t.Fatalf("unexpected eligible search result: items=%+v err=%v", searchItems, err)
+	}
+	roleID := "integrity-reader"
+	if err := store.UpsertFederationRolePoolAccess(ctx, FederationRolePoolAccessRecord{
+		RoleID: roleID, PoolID: poolID, CanSearch: true, CanGet: true, CanResolveManifest: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	canGet, err := store.CanGetFederatedReleaseForPrincipal(ctx, card.ReleaseID, "", []string{roleID})
+	if err != nil || !canGet {
+		t.Fatalf("expected eligible release get, allowed=%v err=%v", canGet, err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federated_release_cards SET title = 'Tampered title' WHERE release_id = $1`, card.ReleaseID); err != nil {
+		t.Fatal(err)
+	}
+	page, err = store.ListFederationReleaseLedger(ctx, FederationReleaseLedgerParams{PoolID: poolID, State: "projection_mismatch", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].ProjectionMatchesSigned {
+		t.Fatalf("expected projection mismatch, got %+v", page)
+	}
+	searchItems, err = store.SearchFederatedReleaseCards(ctx, FederatedReleaseCardSearchParams{Pools: []string{poolID}, Limit: 10})
+	if err != nil || len(searchItems) != 0 {
+		t.Fatalf("expected tampered title to be excluded from search, items=%+v err=%v", searchItems, err)
+	}
+	canGet, err = store.CanGetFederatedReleaseForPrincipal(ctx, card.ReleaseID, "", []string{roleID})
+	if err != nil || canGet {
+		t.Fatalf("expected tampered title to be excluded from get, allowed=%v err=%v", canGet, err)
+	}
+	manifestSource, err := store.FindFederatedManifestSource(ctx, card.ReleaseID)
+	if err != nil || manifestSource != nil {
+		t.Fatalf("expected tampered title to suppress manifest source, source=%+v err=%v", manifestSource, err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federated_release_cards SET title = $2 WHERE release_id = $1`, card.ReleaseID, card.Title); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federated_release_cards SET size_bytes = size_bytes + 1 WHERE release_id = $1`, card.ReleaseID); err != nil {
+		t.Fatal(err)
+	}
+	page, err = store.ListFederationReleaseLedger(ctx, FederationReleaseLedgerParams{PoolID: poolID, State: "projection_mismatch", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("expected signed detail mismatch, got %+v", page)
+	}
+	searchItems, err = store.SearchFederatedReleaseCards(ctx, FederatedReleaseCardSearchParams{Pools: []string{poolID}, Limit: 10})
+	if err != nil || len(searchItems) != 0 {
+		t.Fatalf("expected tampered details to be excluded from search, items=%+v err=%v", searchItems, err)
+	}
+	canGet, err = store.CanGetFederatedReleaseForPrincipal(ctx, card.ReleaseID, "", []string{roleID})
+	if err != nil || canGet {
+		t.Fatalf("expected tampered details to be excluded from get, allowed=%v err=%v", canGet, err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federated_release_cards SET size_bytes = $2 WHERE release_id = $1`, card.ReleaseID, card.SizeBytes); err != nil {
+		t.Fatal(err)
+	}
+	searchItems, err = store.SearchFederatedReleaseCards(ctx, FederatedReleaseCardSearchParams{Pools: []string{poolID}, Limit: 10})
+	if err != nil || len(searchItems) != 1 {
+		t.Fatalf("expected restored signed projection in search, items=%+v err=%v", searchItems, err)
+	}
+	canGet, err = store.CanGetFederatedReleaseForPrincipal(ctx, card.ReleaseID, "", []string{roleID})
+	if err != nil || !canGet {
+		t.Fatalf("expected restored signed projection for get, allowed=%v err=%v", canGet, err)
+	}
+
+	core, err := releasecard.ManifestCoreForLocalRelease(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestBody := manifest.ResolutionManifest{
+		SchemaVersion: "1.0", Type: manifest.Type, ManifestID: card.ManifestID,
+		ReleaseID: card.ReleaseID, ManifestCore: core,
+	}
+	manifestEvent, manifestValidation, err := events.Create(ctx, node, events.CreateOptions{
+		EventType: manifest.Type, Sequence: 2, PreviousEventID: &cardEvent.EventID,
+		CreatedAt: time.Now().UTC(), PoolIDs: []string{poolID}, Visibility: "pool",
+		BodySchema: manifest.BodySchema, Body: manifestBody,
+	})
+	if err != nil || manifestValidation == nil || !manifestValidation.OK {
+		t.Fatalf("create manifest event: validation=%+v err=%v", manifestValidation, err)
+	}
+	if err := store.AppendVerifiedFederationEvent(ctx, manifestEvent, manifestValidation); err != nil {
+		t.Fatal(err)
+	}
+	nzb, err := manifest.GenerateNZB(manifestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tamperedManifest := manifestBody
+	tamperedManifest.ReleaseID = "rel_tampered"
+	if err := store.StoreResolutionManifest(ctx, ResolutionManifestRecord{
+		Manifest: tamperedManifest, SourceNodeID: nodeID, FetchedFromNodeID: nodeID,
+		SourceEventID: manifestEvent.EventID, PoolID: poolID, GeneratedNZB: nzb,
+	}); err == nil {
+		t.Fatal("expected manifest record that differs from its signed source event to be rejected")
+	}
+	if err := store.StoreResolutionManifest(ctx, ResolutionManifestRecord{
+		Manifest: manifestBody, SourceNodeID: nodeID, FetchedFromNodeID: nodeID,
+		SourceEventID: manifestEvent.EventID, PoolID: poolID, GeneratedNZB: nzb,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	allowed, err := store.CanFetchResolutionManifestForSource(ctx, card.ManifestID, card.ReleaseID, poolID, nodeID)
+	if err != nil || !allowed {
+		t.Fatalf("expected exact manifest request bindings to be authorized, allowed=%v err=%v", allowed, err)
+	}
+	for _, mismatch := range []struct{ manifestID, releaseID, poolID string }{
+		{card.ManifestID, "rel_wrong", poolID},
+		{card.ManifestID, card.ReleaseID, "pool.wrong"},
+	} {
+		allowed, err = store.CanFetchResolutionManifestForSource(ctx, mismatch.manifestID, mismatch.releaseID, mismatch.poolID, nodeID)
+		if err != nil || allowed {
+			t.Fatalf("expected mismatched manifest request to be rejected, allowed=%v err=%v", allowed, err)
+		}
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federation_nodes SET status = 'blocked' WHERE node_id = $1`, nodeID); err != nil {
+		t.Fatal(err)
+	}
+	searchItems, err = store.SearchFederatedReleaseCards(ctx, FederatedReleaseCardSearchParams{Pools: []string{poolID}, Limit: 10})
+	if err != nil || len(searchItems) != 0 {
+		t.Fatalf("expected blocked publisher to leave search immediately, items=%+v err=%v", searchItems, err)
+	}
+	if cached, ok, err := store.GetCachedFederatedNZBByReleaseID(ctx, card.ReleaseID); err != nil || ok || cached != nil {
+		t.Fatalf("expected blocked publisher cache suppression, ok=%v bytes=%d err=%v", ok, len(cached), err)
+	}
+	page, err = store.ListFederationReleaseLedger(ctx, FederationReleaseLedgerParams{PoolID: poolID, State: "blocked", Limit: 10})
+	if err != nil || len(page.Items) != 1 {
+		t.Fatalf("expected blocked publisher in release ledger, page=%+v err=%v", page, err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federation_nodes SET status = 'known' WHERE node_id = $1`, nodeID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE resolution_manifests SET generated_nzb = 'tampered'::bytea WHERE manifest_id = $1`, card.ManifestID); err != nil {
+		t.Fatal(err)
+	}
+	repaired, ok, err := store.GetCachedFederatedNZBByReleaseID(ctx, card.ReleaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || !bytes.Equal(repaired, nzb) {
+		t.Fatalf("expected deterministic cache repair, ok=%v bytes=%d", ok, len(repaired))
+	}
+	var integrityStatus string
+	if err := store.DB().QueryRowContext(ctx, `SELECT cache_integrity_status FROM resolution_manifests WHERE manifest_id = $1`, card.ManifestID).Scan(&integrityStatus); err != nil {
+		t.Fatal(err)
+	}
+	if integrityStatus != "verified" {
+		t.Fatalf("cache integrity status=%q", integrityStatus)
+	}
+
+	tombstoneBody := moderation.Tombstone{
+		SchemaVersion: "1.0", Type: moderation.Type,
+		TargetType: moderation.TargetEvent, TargetID: cardEvent.EventID, PoolID: poolID,
+		Reason: "integrity test", Severity: moderation.SeverityReject,
+		EffectiveAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	tombstoneEvent, tombstoneValidation, err := events.Create(ctx, node, events.CreateOptions{
+		EventType: moderation.Type, Sequence: 3, PreviousEventID: &manifestEvent.EventID,
+		CreatedAt: time.Now().UTC(), PoolIDs: []string{poolID}, Visibility: "pool",
+		BodySchema: moderation.BodySchema, Body: tombstoneBody,
+	})
+	if err != nil || tombstoneValidation == nil || !tombstoneValidation.OK {
+		t.Fatalf("create tombstone event: validation=%+v err=%v", tombstoneValidation, err)
+	}
+	if err := store.AppendVerifiedFederationEventWithProjection(ctx, tombstoneEvent, tombstoneValidation, func(projectCtx context.Context) error {
+		return store.ProjectTombstone(projectCtx, TombstoneProjection{
+			Tombstone: tombstoneBody, EventID: tombstoneEvent.EventID, AuthorNodeID: nodeID,
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tombstoned := true
+	eventItems, err := store.ListFederationEventDiagnostics(ctx, FederationEventDiagnosticParams{
+		PoolID: poolID, NodeID: nodeID, EventType: pools.EventTypeReleaseCard,
+		Tombstoned: &tombstoned, Limit: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(eventItems) != 1 || eventItems[0].EventID != cardEvent.EventID || !eventItems[0].Tombstoned {
+		t.Fatalf("unexpected tombstoned event diagnostics: %+v", eventItems)
+	}
+	page, err = store.ListFederationReleaseLedger(ctx, FederationReleaseLedgerParams{PoolID: poolID, State: "tombstoned", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TombstoneSourceEventID != tombstoneEvent.EventID {
+		t.Fatalf("unexpected tombstoned release ledger: %+v", page)
+	}
+	allowed, err = store.CanFetchResolutionManifestForSource(ctx, card.ManifestID, card.ReleaseID, poolID, nodeID)
+	if err != nil || allowed {
+		t.Fatalf("expected source-event tombstone to suppress manifest serving, allowed=%v err=%v", allowed, err)
+	}
+	searchItems, err = store.SearchFederatedReleaseCards(ctx, FederatedReleaseCardSearchParams{Pools: []string{poolID}, Limit: 10})
+	if err != nil || len(searchItems) != 0 {
+		t.Fatalf("expected tombstoned source to leave search immediately, items=%+v err=%v", searchItems, err)
+	}
+	canGet, err = store.CanGetFederatedReleaseForPrincipal(ctx, card.ReleaseID, "", []string{roleID})
+	if err != nil || canGet {
+		t.Fatalf("expected tombstoned source get rejection, allowed=%v err=%v", canGet, err)
+	}
+}

--- a/internal/store/pgindex/federation_integrity_integration_test.go
+++ b/internal/store/pgindex/federation_integrity_integration_test.go
@@ -34,7 +34,7 @@ func TestFederationIntegrityLedgerAndCacheRepairIntegration(t *testing.T) {
 	if err := store.UpsertTrustPool(ctx, TrustPoolRecord{
 		PoolID: poolID, DisplayName: "Integrity", PolicyJSON: json.RawMessage(`{}`),
 		MembershipThreshold: 1, ModerationThreshold: 1, CheckpointWitnessThreshold: 1,
-		AcceptMode: "pool_member", AcceptedEventTypes: []string{pools.EventTypeReleaseCard, manifest.Type, moderation.Type}, Enabled: true,
+		AcceptMode: "pool_member", AcceptedEventTypes: []string{pools.EventTypeReleaseCard, moderation.Type}, Enabled: true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -151,6 +151,17 @@ func TestFederationIntegrityLedgerAndCacheRepairIntegration(t *testing.T) {
 	if err != nil || !canGet {
 		t.Fatalf("expected restored signed projection for get, allowed=%v err=%v", canGet, err)
 	}
+	manifestSource, err = store.FindFederatedManifestSource(ctx, card.ReleaseID)
+	if err != nil || manifestSource == nil {
+		t.Fatalf("expected restored manifest source, source=%+v err=%v", manifestSource, err)
+	}
+	relayAuthorization, err := store.CanAcceptFederationEventForPools(ctx, nodeID, []string{poolID}, manifest.Type)
+	if err != nil || relayAuthorization.Allowed || relayAuthorization.Reason != "event_type_not_allowed" {
+		t.Fatalf("expected manifest to remain outside general relay policy, authorization=%+v err=%v", relayAuthorization, err)
+	}
+	if err := store.AuthorizeFederatedManifestSource(ctx, *manifestSource, ""); err != nil {
+		t.Fatalf("dedicated manifest fetch should authorize independently of relay event types: %v", err)
+	}
 
 	core, err := releasecard.ManifestCoreForLocalRelease(local)
 	if err != nil {
@@ -188,6 +199,49 @@ func TestFederationIntegrityLedgerAndCacheRepairIntegration(t *testing.T) {
 		SourceEventID: manifestEvent.EventID, PoolID: poolID, GeneratedNZB: nzb,
 	}); err != nil {
 		t.Fatal(err)
+	}
+	secondPoolID := "pool.integrity.second"
+	if err := store.UpsertTrustPool(ctx, TrustPoolRecord{
+		PoolID: secondPoolID, DisplayName: "Integrity Second", PolicyJSON: json.RawMessage(`{}`),
+		MembershipThreshold: 1, ModerationThreshold: 1, CheckpointWitnessThreshold: 1,
+		AcceptMode: "pool_member", AcceptedEventTypes: []string{pools.EventTypeReleaseCard}, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertPoolMember(ctx, PoolMemberRecord{
+		PoolID: secondPoolID, NodeID: nodeID, Role: pools.RoleAdmin, Status: pools.StatusActive,
+		AllowedCapabilities: []string{capability.ReleasePublisher, capability.ManifestBuilder, capability.Admin},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	secondManifestEvent, secondManifestValidation, err := events.Create(ctx, node, events.CreateOptions{
+		EventType: manifest.Type, Sequence: 3, PreviousEventID: &manifestEvent.EventID,
+		CreatedAt: time.Now().UTC(), PoolIDs: []string{secondPoolID}, Visibility: "pool",
+		BodySchema: manifest.BodySchema, Body: manifestBody,
+	})
+	if err != nil || secondManifestValidation == nil || !secondManifestValidation.OK {
+		t.Fatalf("create second-pool manifest event: validation=%+v err=%v", secondManifestValidation, err)
+	}
+	if err := store.AppendVerifiedFederationEvent(ctx, secondManifestEvent, secondManifestValidation); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.StoreResolutionManifest(ctx, ResolutionManifestRecord{
+		Manifest: manifestBody, SourceNodeID: nodeID, FetchedFromNodeID: nodeID,
+		SourceEventID: secondManifestEvent.EventID, PoolID: secondPoolID, GeneratedNZB: nzb,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []struct {
+		poolID  string
+		eventID string
+	}{
+		{poolID: poolID, eventID: manifestEvent.EventID},
+		{poolID: secondPoolID, eventID: secondManifestEvent.EventID},
+	} {
+		got, err := store.GetResolutionManifestEvent(ctx, card.ManifestID, expected.poolID)
+		if err != nil || got == nil || got.EventID != expected.eventID {
+			t.Fatalf("manifest event for pool %s = %+v, want %s, err=%v", expected.poolID, got, expected.eventID, err)
+		}
 	}
 	allowed, err := store.CanFetchResolutionManifestForSource(ctx, card.ManifestID, card.ReleaseID, poolID, nodeID)
 	if err != nil || !allowed {
@@ -244,7 +298,7 @@ func TestFederationIntegrityLedgerAndCacheRepairIntegration(t *testing.T) {
 		EffectiveAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	tombstoneEvent, tombstoneValidation, err := events.Create(ctx, node, events.CreateOptions{
-		EventType: moderation.Type, Sequence: 3, PreviousEventID: &manifestEvent.EventID,
+		EventType: moderation.Type, Sequence: 4, PreviousEventID: &secondManifestEvent.EventID,
 		CreatedAt: time.Now().UTC(), PoolIDs: []string{poolID}, Visibility: "pool",
 		BodySchema: moderation.BodySchema, Body: tombstoneBody,
 	})
@@ -257,6 +311,18 @@ func TestFederationIntegrityLedgerAndCacheRepairIntegration(t *testing.T) {
 		})
 	}); err != nil {
 		t.Fatal(err)
+	}
+	var cardStatus, manifestStatus string
+	var cachedNZBPresent bool
+	if err := store.DB().QueryRowContext(ctx, `
+		SELECT card.status, cached.validation_status, cached.generated_nzb IS NOT NULL
+		FROM federated_release_cards card
+		JOIN resolution_manifests cached ON cached.manifest_id = card.manifest_id
+		WHERE card.release_id = $1`, card.ReleaseID).Scan(&cardStatus, &manifestStatus, &cachedNZBPresent); err != nil {
+		t.Fatal(err)
+	}
+	if cardStatus != "accepted" || manifestStatus != "accepted" || !cachedNZBPresent {
+		t.Fatalf("tombstone destructively changed signed projections: card=%s manifest=%s cached=%v", cardStatus, manifestStatus, cachedNZBPresent)
 	}
 	tombstoned := true
 	eventItems, err := store.ListFederationEventDiagnostics(ctx, FederationEventDiagnosticParams{

--- a/internal/store/pgindex/federation_manifest_store.go
+++ b/internal/store/pgindex/federation_manifest_store.go
@@ -1,6 +1,7 @@
 package pgindex
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -8,23 +9,30 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/datallboy/gonzb/internal/gonzbnet/canonical"
+	"github.com/datallboy/gonzb/internal/gonzbnet/capability"
+	"github.com/datallboy/gonzb/internal/gonzbnet/eventbody"
 	"github.com/datallboy/gonzb/internal/gonzbnet/events"
 	"github.com/datallboy/gonzb/internal/gonzbnet/manifest"
+	gonzbnetmetrics "github.com/datallboy/gonzb/internal/gonzbnet/metrics"
 )
 
 type FederatedManifestSource struct {
-	ManifestID   string
-	ReleaseID    string
-	SourceNodeID string
-	PoolID       string
-	BaseURL      string
-	TrustScore   float64
+	ManifestID    string
+	ReleaseID     string
+	SourceNodeID  string
+	SourceEventID string
+	PoolID        string
+	BaseURL       string
+	TrustScore    float64
 }
 
 type ResolutionManifestRecord struct {
 	Manifest              manifest.ResolutionManifest
 	SourceNodeID          string
+	FetchedFromNodeID     string
 	SourceEventID         string
 	PoolID                string
 	CanonicalManifestJSON []byte
@@ -36,6 +44,7 @@ func (s *Store) GetCachedFederatedNZBByReleaseID(ctx context.Context, releaseID 
 		return nil, false, fmt.Errorf("pgindex store is not initialized")
 	}
 	var payload []byte
+	var manifestID, nzbSHA, sourceEventID string
 	_, ttlDays := s.manifestCachePolicy()
 	ttlClause := ""
 	args := []any{strings.TrimSpace(releaseID)}
@@ -44,32 +53,220 @@ func (s *Store) GetCachedFederatedNZBByReleaseID(ctx context.Context, releaseID 
 		args = append(args, ttlDays)
 	}
 	err := s.db.QueryRowContext(ctx, `
-		SELECT rm.generated_nzb
+		SELECT rm.manifest_id, rm.generated_nzb, COALESCE(rm.nzb_sha256, ''),
+		       COALESCE(rm.source_event_id, '')
 		FROM resolution_manifests rm
 		JOIN federated_release_cards c ON c.manifest_id = rm.manifest_id
 		WHERE c.release_id = $1
 		  AND rm.validation_status = 'accepted'
+		  AND rm.cache_integrity_status <> 'failed'
 		  AND rm.generated_nzb IS NOT NULL
-		  AND NOT EXISTS (
+		  AND rm.source_event_id IS NOT NULL
+		  AND EXISTS (
 		    SELECT 1
-		    FROM tombstones t
-		    WHERE t.active = TRUE
-		      AND t.severity IN ('reject', 'local_only')
-		      AND (t.expires_at IS NULL OR t.expires_at > NOW())
-		      AND t.effective_at <= NOW()
-		      AND (
-		        (t.target_type = 'release' AND t.target_id = c.release_id)
-		        OR (t.target_type = 'manifest' AND t.target_id = rm.manifest_id)
+		    FROM federated_release_sources source
+		    JOIN federation_nodes node ON node.node_id = source.source_node_id
+		    JOIN trust_pools pool ON pool.pool_id = source.pool_id
+		      AND pool.enabled = TRUE
+		    JOIN pool_members member ON member.pool_id = source.pool_id
+		      AND member.node_id = source.source_node_id
+		      AND member.status = 'active'
+		    JOIN federation_nodes manifest_author ON manifest_author.node_id = rm.source_node_id
+		    JOIN pool_members manifest_member ON manifest_member.pool_id = source.pool_id
+		      AND manifest_member.node_id = rm.source_node_id
+		      AND manifest_member.status = 'active'
+		    WHERE source.release_id = c.release_id
+		      AND COALESCE(source.manifest_id, '') = rm.manifest_id
+		      AND node.status NOT IN ('blocked', 'forked')
+		      AND manifest_author.status NOT IN ('blocked', 'forked')
+		      AND (pool.min_node_trust_score <= 0 OR node.local_trust_score >= pool.min_node_trust_score)
+		      AND (pool.min_node_trust_score <= 0 OR manifest_author.local_trust_score >= pool.min_node_trust_score)
+		      AND (member.role = 'admin' OR member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])
+		      AND (manifest_member.role = 'admin' OR manifest_member.allowed_capabilities ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
+		      AND NOT EXISTS (
+		        SELECT 1 FROM federated_release_publication_states ps
+		        WHERE ps.release_id = source.release_id
+		          AND ps.source_node_id = source.source_node_id
+		          AND ps.pool_id = source.pool_id
+		          AND ps.state = 'withdrawn'
+		      )
+		      AND NOT EXISTS (
+		        SELECT 1
+		        FROM tombstones t
+		        WHERE t.active = TRUE
+		          AND t.severity IN ('hide', 'reject', 'local_only')
+		          AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		          AND t.effective_at <= NOW()
+		          AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
+		          AND (
+		            (t.target_type = 'release' AND t.target_id = c.release_id)
+		            OR (t.target_type = 'manifest' AND t.target_id = rm.manifest_id)
+		            OR (t.target_type = 'event' AND t.target_id IN (source.source_event_id, rm.source_event_id))
+		            OR (t.target_type = 'node' AND t.target_id IN (source.source_node_id, rm.source_node_id))
+		            OR (t.target_type = 'pool_member' AND t.target_id IN (source.source_node_id, rm.source_node_id))
+		          )
 		      )
 		  )`+ttlClause+`
-		  LIMIT 1`, args...).Scan(&payload)
+		  LIMIT 1`, args...).Scan(&manifestID, &payload, &nzbSHA, &sourceEventID)
 	if err == nil {
-		return payload, true, nil
+		if matchesNZBSHA256(payload, nzbSHA) {
+			return payload, true, nil
+		}
+		gonzbnetmetrics.Default.Add(gonzbnetmetrics.ManifestCacheIntegrityFailuresTotal, 1)
+		return s.repairCachedFederatedNZB(ctx, manifestID, strings.TrimSpace(releaseID), sourceEventID)
 	}
 	if isNoRows(err) {
 		return nil, false, nil
 	}
 	return nil, false, fmt.Errorf("get cached federated nzb: %w", err)
+}
+
+func (s *Store) GetFederatedNZBSHA256ByReleaseID(ctx context.Context, releaseID string) (string, bool, error) {
+	if s == nil || s.db == nil {
+		return "", false, fmt.Errorf("pgindex store is not initialized")
+	}
+	var hash string
+	_, ttlDays := s.manifestCachePolicy()
+	ttlClause := ""
+	args := []any{strings.TrimSpace(releaseID)}
+	if ttlDays > 0 {
+		ttlClause = " AND rm.updated_at >= NOW() - ($2 * INTERVAL '1 day')"
+		args = append(args, ttlDays)
+	}
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COALESCE(rm.nzb_sha256, '')
+		FROM resolution_manifests rm
+		JOIN federated_release_cards card ON card.manifest_id = rm.manifest_id
+		WHERE card.release_id = $1
+		  AND rm.validation_status = 'accepted'
+		  AND rm.cache_integrity_status <> 'failed'
+		  AND rm.generated_nzb IS NOT NULL
+		  AND rm.nzb_sha256 IS NOT NULL
+		  AND rm.source_event_id IS NOT NULL
+		  AND EXISTS (
+		    SELECT 1
+		    FROM federated_release_sources source
+		    JOIN federation_nodes node ON node.node_id = source.source_node_id
+		    JOIN trust_pools pool ON pool.pool_id = source.pool_id
+		      AND pool.enabled = TRUE
+		    JOIN pool_members member ON member.pool_id = source.pool_id
+		      AND member.node_id = source.source_node_id
+		      AND member.status = 'active'
+		    JOIN federation_nodes manifest_author ON manifest_author.node_id = rm.source_node_id
+		    JOIN pool_members manifest_member ON manifest_member.pool_id = source.pool_id
+		      AND manifest_member.node_id = rm.source_node_id
+		      AND manifest_member.status = 'active'
+		    WHERE source.release_id = card.release_id
+		      AND COALESCE(source.manifest_id, '') = rm.manifest_id
+		      AND node.status NOT IN ('blocked', 'forked')
+		      AND manifest_author.status NOT IN ('blocked', 'forked')
+		      AND (pool.min_node_trust_score <= 0 OR node.local_trust_score >= pool.min_node_trust_score)
+		      AND (pool.min_node_trust_score <= 0 OR manifest_author.local_trust_score >= pool.min_node_trust_score)
+		      AND (member.role = 'admin' OR member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])
+		      AND (manifest_member.role = 'admin' OR manifest_member.allowed_capabilities ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
+		      AND NOT EXISTS (
+		        SELECT 1 FROM federated_release_publication_states ps
+		        WHERE ps.release_id = source.release_id
+		          AND ps.source_node_id = source.source_node_id
+		          AND ps.pool_id = source.pool_id
+		          AND ps.state = 'withdrawn'
+		      )
+		      AND NOT EXISTS (
+		        SELECT 1 FROM tombstones t
+		        WHERE t.active = TRUE
+		          AND t.severity IN ('hide','reject','local_only')
+		          AND t.effective_at <= NOW()
+		          AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		          AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
+		          AND (
+		            (t.target_type = 'release' AND t.target_id = card.release_id)
+		            OR (t.target_type = 'manifest' AND t.target_id = rm.manifest_id)
+		            OR (t.target_type = 'event' AND t.target_id IN (source.source_event_id, rm.source_event_id))
+		            OR (t.target_type = 'node' AND t.target_id IN (source.source_node_id, rm.source_node_id))
+		            OR (t.target_type = 'pool_member' AND t.target_id IN (source.source_node_id, rm.source_node_id))
+		          )
+		      )
+		  )`+ttlClause+`
+		LIMIT 1`, args...).Scan(&hash)
+	if isNoRows(err) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("get federated nzb checksum: %w", err)
+	}
+	if strings.TrimSpace(hash) == "" {
+		return "", false, nil
+	}
+	return hash, true, nil
+}
+
+func (s *Store) repairCachedFederatedNZB(ctx context.Context, manifestID, releaseID, sourceEventID string) ([]byte, bool, error) {
+	markFailed := func(reason string) {
+		_, _ = s.db.ExecContext(ctx, `
+			UPDATE resolution_manifests
+			SET generated_nzb = NULL,
+			    cache_integrity_status = 'failed',
+			    cache_integrity_failed_at = NOW(),
+			    cache_integrity_error = $2,
+			    updated_at = NOW()
+			WHERE manifest_id = $1`, manifestID, reason)
+	}
+
+	if strings.TrimSpace(sourceEventID) == "" {
+		markFailed("cached_nzb_source_event_missing")
+		return nil, false, nil
+	}
+	event, err := s.GetFederationEvent(ctx, sourceEventID)
+	if err != nil {
+		markFailed("cached_nzb_source_event_read_failed")
+		return nil, false, nil
+	}
+	validation, err := events.Verify(event)
+	if err != nil || validation == nil || !validation.OK {
+		markFailed("cached_nzb_source_event_verification_failed")
+		return nil, false, nil
+	}
+	if err := eventbody.Validate(event, time.Now().UTC(), 2*time.Minute); err != nil {
+		markFailed("cached_nzb_source_event_body_invalid")
+		return nil, false, nil
+	}
+	var item manifest.ResolutionManifest
+	if err := json.Unmarshal(event.Body, &item); err != nil {
+		markFailed("cached_nzb_manifest_decode_failed")
+		return nil, false, nil
+	}
+	if item.ManifestID != manifestID || item.ReleaseID != releaseID {
+		markFailed("cached_nzb_manifest_binding_mismatch")
+		return nil, false, nil
+	}
+	generated, err := manifest.GenerateNZB(item)
+	if err != nil {
+		markFailed("cached_nzb_regeneration_failed")
+		return nil, false, nil
+	}
+	hash := nzbSHA256(generated)
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE resolution_manifests
+		SET generated_nzb = $2,
+		    nzb_sha256 = $3,
+		    cache_integrity_status = 'verified',
+		    cache_integrity_failed_at = NULL,
+		    cache_integrity_error = NULL,
+		    updated_at = NOW()
+		WHERE manifest_id = $1`, manifestID, generated, hash); err != nil {
+		return nil, false, fmt.Errorf("repair cached federated nzb: %w", err)
+	}
+	return generated, true, nil
+}
+
+func matchesNZBSHA256(payload []byte, expected string) bool {
+	expected = strings.TrimSpace(expected)
+	return expected != "" && strings.EqualFold(nzbSHA256(payload), expected)
+}
+
+func nzbSHA256(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func (s *Store) FindFederatedManifestSource(ctx context.Context, releaseID string) (*FederatedManifestSource, error) {
@@ -78,14 +275,57 @@ func (s *Store) FindFederatedManifestSource(ctx context.Context, releaseID strin
 	}
 	var out FederatedManifestSource
 	err := s.db.QueryRowContext(ctx, `
-		SELECT c.manifest_id, c.release_id, fs.source_node_id, fs.pool_id,
+		SELECT c.manifest_id, c.release_id, fs.source_node_id, rs.source_event_id, fs.pool_id,
 		       COALESCE(n.base_url, ''), fs.trust_score
 		FROM federated_release_cards c
 		JOIN federated_manifest_sources fs ON fs.manifest_id = c.manifest_id
+		JOIN federated_release_sources rs ON rs.release_id = c.release_id
+		 AND rs.source_node_id = fs.source_node_id
+		 AND rs.pool_id = fs.pool_id
+		 AND COALESCE(rs.manifest_id, '') = fs.manifest_id
+		JOIN federation_events release_event ON release_event.event_id = rs.source_event_id
 		JOIN federation_nodes n ON n.node_id = fs.source_node_id
+		JOIN trust_pools pool ON pool.pool_id = fs.pool_id AND pool.enabled = TRUE
+		JOIN pool_members member ON member.pool_id = fs.pool_id
+		 AND member.node_id = fs.source_node_id
+		 AND member.status = 'active'
 		WHERE c.release_id = $1
 		  AND c.manifest_id IS NOT NULL
 		  AND fs.advertised = TRUE
+		  AND n.status NOT IN ('blocked', 'forked')
+		  AND (pool.min_node_trust_score <= 0 OR n.local_trust_score >= pool.min_node_trust_score)
+		  AND (member.role = 'admin' OR member.allowed_capabilities ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
+		  AND release_event.validation_status = 'accepted'
+		  AND release_event.event_type = 'ReleaseCard'
+		  AND release_event.author_node_id = rs.source_node_id
+		  AND release_event.pool_ids @> jsonb_build_array(rs.pool_id)
+		  AND c.body_json = release_event.body_json
+		  AND COALESCE(release_event.body_json->>'release_id', '') = rs.release_id
+		  AND COALESCE(release_event.body_json->>'manifest_id', '') = COALESCE(rs.manifest_id, '')
+		  AND c.title = COALESCE(release_event.body_json->>'title', '')
+		  AND c.normalized_title = COALESCE(release_event.body_json->>'normalized_title', '')
+		  AND c.category_json = COALESCE(release_event.body_json->'category', '[]'::jsonb)
+		  AND c.newznab_categories = COALESCE(release_event.body_json->'newznab_categories', '[]'::jsonb)
+		  AND c.size_bytes IS NOT DISTINCT FROM NULLIF(release_event.body_json->>'size_bytes', '')::bigint
+		  AND c.posted_at IS NOT DISTINCT FROM NULLIF(release_event.body_json->>'posted_at', '')::timestamptz
+		  AND c.groups_json = COALESCE(release_event.body_json->'groups', '[]'::jsonb)
+		  AND c.file_count IS NOT DISTINCT FROM NULLIF(release_event.body_json->>'file_count', '')::integer
+		  AND c.segment_count IS NOT DISTINCT FROM NULLIF(release_event.body_json->>'segment_count', '')::integer
+		  AND COALESCE(c.poster_hash, '') = COALESCE(release_event.body_json->>'poster_hash', '')
+		  AND c.subject_fingerprint = COALESCE(release_event.body_json->>'subject_fingerprint', '')
+		  AND c.file_fingerprint = COALESCE(release_event.body_json->>'file_fingerprint', '')
+		  AND c.media_json = COALESCE(release_event.body_json->'media', '{}'::jsonb)
+		  AND c.quality_json = COALESCE(release_event.body_json->'quality', '{}'::jsonb)
+		  AND c.flags_json = COALESCE(release_event.body_json->'flags', '{}'::jsonb)
+		  AND c.resolution_json = COALESCE(release_event.body_json->'resolution', '{}'::jsonb)
+		  AND c.expires_at IS NOT DISTINCT FROM NULLIF(release_event.body_json->>'expires_at', '')::timestamptz
+		  AND NOT EXISTS (
+		    SELECT 1 FROM federated_release_publication_states ps
+		    WHERE ps.release_id = rs.release_id
+		      AND ps.source_node_id = rs.source_node_id
+		      AND ps.pool_id = rs.pool_id
+		      AND ps.state = 'withdrawn'
+		  )
 		  AND (
 		    COALESCE(c.flags_json->>'passworded', 'unknown') <> 'passworded'
 		    OR COALESCE((n.capabilities->>'manifest_archive_password')::boolean, FALSE) = TRUE
@@ -100,6 +340,9 @@ func (s *Store) FindFederatedManifestSource(ctx context.Context, releaseID strin
 		      AND (
 		        (t.target_type = 'release' AND t.target_id = c.release_id)
 		        OR (t.target_type = 'manifest' AND t.target_id = c.manifest_id)
+		        OR (t.target_type = 'event' AND t.target_id = rs.source_event_id)
+		        OR (t.target_type = 'node' AND t.target_id = fs.source_node_id)
+		        OR (t.target_type = 'pool_member' AND t.target_id = fs.source_node_id)
 		      )
 		      AND (t.pool_id IS NULL OR t.pool_id = fs.pool_id)
 		  )
@@ -108,6 +351,7 @@ func (s *Store) FindFederatedManifestSource(ctx context.Context, releaseID strin
 		&out.ManifestID,
 		&out.ReleaseID,
 		&out.SourceNodeID,
+		&out.SourceEventID,
 		&out.PoolID,
 		&out.BaseURL,
 		&out.TrustScore,
@@ -121,11 +365,97 @@ func (s *Store) FindFederatedManifestSource(ctx context.Context, releaseID strin
 	return &out, nil
 }
 
+// AuthorizeFederatedManifestSource rechecks serving-node and signed-author
+// provenance at the point a manifest is fetched or accepted.
+func (s *Store) AuthorizeFederatedManifestSource(ctx context.Context, source FederatedManifestSource, authorNodeID string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("pgindex store is not initialized")
+	}
+	servingNodeID := strings.TrimSpace(source.SourceNodeID)
+	authorNodeID = strings.TrimSpace(authorNodeID)
+	if authorNodeID == "" {
+		authorNodeID = servingNodeID
+	}
+	if servingNodeID == "" || strings.TrimSpace(source.ReleaseID) == "" || strings.TrimSpace(source.ManifestID) == "" || strings.TrimSpace(source.PoolID) == "" {
+		return fmt.Errorf("manifest source provenance is incomplete")
+	}
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+		  SELECT 1
+		  FROM federated_manifest_sources fs
+		  JOIN federated_release_sources rs ON rs.release_id = fs.release_id
+		    AND rs.source_node_id = fs.source_node_id
+		    AND rs.pool_id = fs.pool_id
+		    AND COALESCE(rs.manifest_id, '') = fs.manifest_id
+		  WHERE fs.manifest_id = $1
+		    AND fs.release_id = $2
+		    AND fs.source_node_id = $3
+		    AND fs.pool_id = $4
+		    AND fs.advertised = TRUE
+		    AND ($5 = '' OR rs.source_event_id = $5)
+		    AND NOT EXISTS (
+		      SELECT 1 FROM federated_release_publication_states ps
+		      WHERE ps.release_id = rs.release_id
+		        AND ps.source_node_id = rs.source_node_id
+		        AND ps.pool_id = rs.pool_id
+		        AND ps.state = 'withdrawn'
+		    )
+		    AND NOT EXISTS (
+		      SELECT 1 FROM tombstones t
+		      WHERE t.active = TRUE
+		        AND t.severity IN ('hide','reject','local_only')
+		        AND t.effective_at <= NOW()
+		        AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		        AND (t.pool_id IS NULL OR t.pool_id = fs.pool_id)
+		        AND (
+		          (t.target_type = 'release' AND t.target_id = fs.release_id)
+		          OR (t.target_type = 'manifest' AND t.target_id = fs.manifest_id)
+		          OR (t.target_type = 'event' AND t.target_id = rs.source_event_id)
+		          OR (t.target_type = 'node' AND t.target_id IN (fs.source_node_id, $6))
+		          OR (t.target_type = 'pool_member' AND t.target_id IN (fs.source_node_id, $6))
+		        )
+		    )
+		)`, source.ManifestID, source.ReleaseID, servingNodeID, source.PoolID, source.SourceEventID, authorNodeID).Scan(&exists); err != nil {
+		return fmt.Errorf("check manifest source provenance: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("manifest source is no longer advertised or has been suppressed")
+	}
+	servingAuth, err := s.CanAcceptFederationEventForPools(ctx, servingNodeID, []string{source.PoolID}, manifest.Type)
+	if err != nil {
+		return err
+	}
+	if !servingAuth.Allowed {
+		return fmt.Errorf("manifest serving node is not authorized: %s", servingAuth.Reason)
+	}
+	if authorNodeID != servingNodeID {
+		cacheAllowed, err := s.PoolMemberHasCapability(ctx, source.PoolID, servingNodeID, []string{capability.ManifestCache})
+		if err != nil {
+			return err
+		}
+		if !cacheAllowed {
+			return fmt.Errorf("manifest serving node is not an authorized cache")
+		}
+	}
+	authorAuth, err := s.CanAcceptFederationEventForPools(ctx, authorNodeID, []string{source.PoolID}, manifest.Type)
+	if err != nil {
+		return err
+	}
+	if !authorAuth.Allowed {
+		return fmt.Errorf("manifest author is not authorized: %s", authorAuth.Reason)
+	}
+	return nil
+}
+
 func (s *Store) StoreResolutionManifest(ctx context.Context, record ResolutionManifestRecord) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("pgindex store is not initialized")
 	}
 	if _, err := manifest.Validate(record.Manifest); err != nil {
+		return err
+	}
+	if err := s.validateResolutionManifestProvenance(ctx, record); err != nil {
 		return err
 	}
 	bodyJSON, err := json.Marshal(record.Manifest)
@@ -141,8 +471,7 @@ func (s *Store) StoreResolutionManifest(ctx context.Context, record ResolutionMa
 	}
 	nzbSHA := ""
 	if len(record.GeneratedNZB) > 0 {
-		sum := sha256.Sum256(record.GeneratedNZB)
-		nzbSHA = "sha256:" + hex.EncodeToString(sum[:])
+		nzbSHA = nzbSHA256(record.GeneratedNZB)
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -159,17 +488,18 @@ func (s *Store) StoreResolutionManifest(ctx context.Context, record ResolutionMa
 	}
 	if _, err = tx.ExecContext(ctx, `
 		INSERT INTO resolution_manifests (
-			manifest_id, release_id, source_node_id, source_event_id, encoding,
+			manifest_id, release_id, source_node_id, fetched_from_node_id, source_event_id, encoding,
 			compression, encrypted, canonical_manifest_json, body_json, body_blob,
 			nzb_sha256, generated_nzb, fetched_at, verified_at, validation_status,
-			updated_at
+			cache_integrity_status, cache_integrity_failed_at, cache_integrity_error, updated_at
 		)
-		VALUES ($1, $2, NULLIF($3, ''), NULLIF($4, ''), 'jcs-json',
-		        NULLIF($5, ''), $6, $7, $8::jsonb, $9,
-		        NULLIF($10, ''), $11, NOW(), NOW(), 'accepted', NOW())
+		VALUES ($1, $2, NULLIF($3, ''), NULLIF($4, ''), NULLIF($5, ''), 'jcs-json',
+		        NULLIF($6, ''), $7, $8, $9::jsonb, $10,
+		        NULLIF($11, ''), $12, NOW(), NOW(), 'accepted', 'verified', NULL, NULL, NOW())
 		ON CONFLICT (manifest_id) DO UPDATE SET
 			release_id = EXCLUDED.release_id,
 			source_node_id = COALESCE(EXCLUDED.source_node_id, resolution_manifests.source_node_id),
+			fetched_from_node_id = COALESCE(EXCLUDED.fetched_from_node_id, resolution_manifests.fetched_from_node_id),
 			source_event_id = COALESCE(EXCLUDED.source_event_id, resolution_manifests.source_event_id),
 			compression = EXCLUDED.compression,
 			encrypted = EXCLUDED.encrypted,
@@ -182,10 +512,14 @@ func (s *Store) StoreResolutionManifest(ctx context.Context, record ResolutionMa
 			verified_at = NOW(),
 			validation_status = 'accepted',
 			rejection_reason = NULL,
+			cache_integrity_status = 'verified',
+			cache_integrity_failed_at = NULL,
+			cache_integrity_error = NULL,
 			updated_at = NOW()`,
 		record.Manifest.ManifestID,
 		record.Manifest.ReleaseID,
 		record.SourceNodeID,
+		record.FetchedFromNodeID,
 		record.SourceEventID,
 		record.Manifest.Compression,
 		record.Manifest.Encrypted,
@@ -245,6 +579,51 @@ func (s *Store) StoreResolutionManifest(ctx context.Context, record ResolutionMa
 	return tx.Commit()
 }
 
+func (s *Store) validateResolutionManifestProvenance(ctx context.Context, record ResolutionManifestRecord) error {
+	sourceNodeID := strings.TrimSpace(record.SourceNodeID)
+	sourceEventID := strings.TrimSpace(record.SourceEventID)
+	poolID := strings.TrimSpace(record.PoolID)
+	if sourceNodeID == "" || sourceEventID == "" || poolID == "" {
+		return fmt.Errorf("resolution manifest source_node_id, source_event_id, and pool_id are required")
+	}
+	event, err := s.GetFederationEvent(ctx, sourceEventID)
+	if err != nil {
+		return fmt.Errorf("read resolution manifest source event: %w", err)
+	}
+	validation, err := events.Verify(event)
+	if err != nil || validation == nil || !validation.OK {
+		return fmt.Errorf("resolution manifest source event verification failed")
+	}
+	if err := eventbody.Validate(event, time.Now().UTC(), 2*time.Minute); err != nil {
+		return fmt.Errorf("resolution manifest source event body is invalid: %w", err)
+	}
+	if event.EventType != manifest.Type || event.BodySchema != manifest.BodySchema {
+		return fmt.Errorf("resolution manifest source event type or schema mismatch")
+	}
+	if event.AuthorNodeID != sourceNodeID {
+		return fmt.Errorf("resolution manifest source author mismatch")
+	}
+	if len(event.PoolIDs) != 1 || strings.TrimSpace(event.PoolIDs[0]) != poolID {
+		return fmt.Errorf("resolution manifest source pool mismatch")
+	}
+	var signedManifest manifest.ResolutionManifest
+	if err := json.Unmarshal(event.Body, &signedManifest); err != nil {
+		return fmt.Errorf("decode resolution manifest source event: %w", err)
+	}
+	signedCanonical, err := canonical.Marshal(signedManifest)
+	if err != nil {
+		return err
+	}
+	recordCanonical, err := canonical.Marshal(record.Manifest)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(signedCanonical, recordCanonical) {
+		return fmt.Errorf("resolution manifest does not match signed source event")
+	}
+	return nil
+}
+
 func (s *Store) GetResolutionManifest(ctx context.Context, manifestID string) (*manifest.ResolutionManifest, error) {
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("pgindex store is not initialized")
@@ -300,6 +679,75 @@ func (s *Store) CanFetchResolutionManifest(ctx context.Context, manifestID, node
 			  AND pm.status = 'active'
 		)`, strings.TrimSpace(manifestID), strings.TrimSpace(nodeID)).Scan(&ok); err != nil {
 		return false, fmt.Errorf("check manifest fetch authorization: %w", err)
+	}
+	return ok, nil
+}
+
+func (s *Store) CanFetchResolutionManifestForSource(ctx context.Context, manifestID, releaseID, poolID, nodeID string) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, fmt.Errorf("pgindex store is not initialized")
+	}
+	var ok bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+		  SELECT 1
+		  FROM federated_manifest_sources fs
+		  JOIN federated_release_sources source ON source.release_id = fs.release_id
+		    AND source.source_node_id = fs.source_node_id
+		    AND source.pool_id = fs.pool_id
+		    AND COALESCE(source.manifest_id, '') = fs.manifest_id
+		  JOIN resolution_manifests rm ON rm.manifest_id = fs.manifest_id
+		    AND rm.release_id = fs.release_id
+		    AND rm.validation_status = 'accepted'
+		  JOIN federation_events manifest_event ON manifest_event.event_id = rm.source_event_id
+		  JOIN trust_pools pool ON pool.pool_id = fs.pool_id AND pool.enabled = TRUE
+		  JOIN federation_nodes source_node ON source_node.node_id = fs.source_node_id
+		  JOIN pool_members source_member ON source_member.pool_id = fs.pool_id
+		    AND source_member.node_id = fs.source_node_id
+		    AND source_member.status = 'active'
+		  JOIN federation_nodes author_node ON author_node.node_id = manifest_event.author_node_id
+		  JOIN pool_members author_member ON author_member.pool_id = fs.pool_id
+		    AND author_member.node_id = manifest_event.author_node_id
+		    AND author_member.status = 'active'
+		  JOIN pool_members requester_member ON requester_member.pool_id = fs.pool_id
+		    AND requester_member.node_id = $4
+		    AND requester_member.status = 'active'
+		  JOIN federation_nodes requester ON requester.node_id = requester_member.node_id
+		  WHERE fs.manifest_id = $1
+		    AND fs.release_id = $2
+		    AND fs.pool_id = $3
+		    AND fs.advertised = TRUE
+		    AND requester.status NOT IN ('blocked', 'forked')
+		    AND source_node.status NOT IN ('blocked', 'forked')
+		    AND author_node.status NOT IN ('blocked', 'forked')
+		    AND (pool.min_node_trust_score <= 0 OR source_node.local_trust_score >= pool.min_node_trust_score)
+		    AND (pool.min_node_trust_score <= 0 OR author_node.local_trust_score >= pool.min_node_trust_score)
+		    AND (source_member.role = 'admin' OR source_member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])
+		    AND (author_member.role = 'admin' OR author_member.allowed_capabilities ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
+		    AND NOT EXISTS (
+		      SELECT 1 FROM federated_release_publication_states ps
+		      WHERE ps.release_id = source.release_id
+		        AND ps.source_node_id = source.source_node_id
+		        AND ps.pool_id = source.pool_id
+		        AND ps.state = 'withdrawn'
+		    )
+		    AND NOT EXISTS (
+		      SELECT 1 FROM tombstones t
+		      WHERE t.active = TRUE
+		        AND t.severity IN ('hide','reject','local_only')
+		        AND t.effective_at <= NOW()
+		        AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		        AND (t.pool_id IS NULL OR t.pool_id = fs.pool_id)
+		        AND (
+		          (t.target_type = 'release' AND t.target_id = fs.release_id)
+		          OR (t.target_type = 'manifest' AND t.target_id = fs.manifest_id)
+		          OR (t.target_type = 'event' AND t.target_id IN (source.source_event_id, manifest_event.event_id))
+		          OR (t.target_type = 'node' AND t.target_id IN (source.source_node_id, manifest_event.author_node_id, requester_member.node_id))
+		          OR (t.target_type = 'pool_member' AND t.target_id IN (source.source_node_id, manifest_event.author_node_id, requester_member.node_id))
+		        )
+		    )
+		)`, strings.TrimSpace(manifestID), strings.TrimSpace(releaseID), strings.TrimSpace(poolID), strings.TrimSpace(nodeID)).Scan(&ok); err != nil {
+		return false, fmt.Errorf("check manifest source fetch authorization: %w", err)
 	}
 	return ok, nil
 }

--- a/internal/store/pgindex/federation_manifest_store.go
+++ b/internal/store/pgindex/federation_manifest_store.go
@@ -54,59 +54,66 @@ func (s *Store) GetCachedFederatedNZBByReleaseID(ctx context.Context, releaseID 
 	}
 	err := s.db.QueryRowContext(ctx, `
 		SELECT rm.manifest_id, rm.generated_nzb, COALESCE(rm.nzb_sha256, ''),
-		       COALESCE(rm.source_event_id, '')
+		       manifest_source.source_event_id
 		FROM resolution_manifests rm
 		JOIN federated_release_cards c ON c.manifest_id = rm.manifest_id
+		JOIN federated_release_sources source ON source.release_id = c.release_id
+		  AND COALESCE(source.manifest_id, '') = rm.manifest_id
+		  AND source.resolvable = TRUE
+		JOIN federated_manifest_sources advertised ON advertised.manifest_id = rm.manifest_id
+		  AND advertised.release_id = source.release_id
+		  AND advertised.source_node_id = source.source_node_id
+		  AND advertised.pool_id = source.pool_id
+		  AND advertised.advertised = TRUE
+		JOIN resolution_manifest_events manifest_source ON manifest_source.manifest_id = rm.manifest_id
+		  AND manifest_source.pool_id = source.pool_id
+		JOIN federation_events manifest_event ON manifest_event.event_id = manifest_source.source_event_id
+		  AND manifest_event.event_type = 'ResolutionManifest'
+		  AND manifest_event.validation_status = 'accepted'
+		  AND manifest_event.body_json->>'manifest_id' = rm.manifest_id
+		  AND manifest_event.body_json->>'release_id' = c.release_id
+		  AND manifest_event.pool_ids = jsonb_build_array(source.pool_id)
+		JOIN federation_nodes node ON node.node_id = source.source_node_id
+		JOIN trust_pools pool ON pool.pool_id = source.pool_id AND pool.enabled = TRUE
+		JOIN pool_members member ON member.pool_id = source.pool_id
+		  AND member.node_id = source.source_node_id AND member.status = 'active'
+		JOIN federation_nodes manifest_author ON manifest_author.node_id = manifest_source.author_node_id
+		  AND manifest_author.node_id = manifest_event.author_node_id
+		JOIN pool_members manifest_member ON manifest_member.pool_id = source.pool_id
+		  AND manifest_member.node_id = manifest_source.author_node_id AND manifest_member.status = 'active'
 		WHERE c.release_id = $1
 		  AND rm.validation_status = 'accepted'
 		  AND rm.cache_integrity_status <> 'failed'
 		  AND rm.generated_nzb IS NOT NULL
-		  AND rm.source_event_id IS NOT NULL
-		  AND EXISTS (
-		    SELECT 1
-		    FROM federated_release_sources source
-		    JOIN federation_nodes node ON node.node_id = source.source_node_id
-		    JOIN trust_pools pool ON pool.pool_id = source.pool_id
-		      AND pool.enabled = TRUE
-		    JOIN pool_members member ON member.pool_id = source.pool_id
-		      AND member.node_id = source.source_node_id
-		      AND member.status = 'active'
-		    JOIN federation_nodes manifest_author ON manifest_author.node_id = rm.source_node_id
-		    JOIN pool_members manifest_member ON manifest_member.pool_id = source.pool_id
-		      AND manifest_member.node_id = rm.source_node_id
-		      AND manifest_member.status = 'active'
-		    WHERE source.release_id = c.release_id
-		      AND COALESCE(source.manifest_id, '') = rm.manifest_id
-		      AND node.status NOT IN ('blocked', 'forked')
-		      AND manifest_author.status NOT IN ('blocked', 'forked')
-		      AND (pool.min_node_trust_score <= 0 OR node.local_trust_score >= pool.min_node_trust_score)
-		      AND (pool.min_node_trust_score <= 0 OR manifest_author.local_trust_score >= pool.min_node_trust_score)
-		      AND (member.role = 'admin' OR member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])
-		      AND (manifest_member.role = 'admin' OR manifest_member.allowed_capabilities ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
-		      AND NOT EXISTS (
-		        SELECT 1 FROM federated_release_publication_states ps
-		        WHERE ps.release_id = source.release_id
-		          AND ps.source_node_id = source.source_node_id
-		          AND ps.pool_id = source.pool_id
-		          AND ps.state = 'withdrawn'
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1
-		        FROM tombstones t
-		        WHERE t.active = TRUE
-		          AND t.severity IN ('hide', 'reject', 'local_only')
-		          AND (t.expires_at IS NULL OR t.expires_at > NOW())
-		          AND t.effective_at <= NOW()
-		          AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
-		          AND (
-		            (t.target_type = 'release' AND t.target_id = c.release_id)
-		            OR (t.target_type = 'manifest' AND t.target_id = rm.manifest_id)
-		            OR (t.target_type = 'event' AND t.target_id IN (source.source_event_id, rm.source_event_id))
-		            OR (t.target_type = 'node' AND t.target_id IN (source.source_node_id, rm.source_node_id))
-		            OR (t.target_type = 'pool_member' AND t.target_id IN (source.source_node_id, rm.source_node_id))
-		          )
+		  AND node.status NOT IN ('blocked', 'forked')
+		  AND manifest_author.status NOT IN ('blocked', 'forked')
+		  AND (pool.min_node_trust_score <= 0 OR node.local_trust_score >= pool.min_node_trust_score)
+		  AND (pool.min_node_trust_score <= 0 OR manifest_author.local_trust_score >= pool.min_node_trust_score)
+		  AND (member.role = 'admin' OR COALESCE(member.allowed_capabilities, '[]'::jsonb) ?| ARRAY['scanner','indexer','release_publisher'])
+		  AND (manifest_member.role = 'admin' OR COALESCE(manifest_member.allowed_capabilities, '[]'::jsonb) ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
+		  AND NOT EXISTS (
+		    SELECT 1 FROM federated_release_publication_states ps
+		    WHERE ps.release_id = source.release_id
+		      AND ps.source_node_id = source.source_node_id
+		      AND ps.pool_id = source.pool_id
+		      AND ps.state = 'withdrawn'
+		  )
+		  AND NOT EXISTS (
+		    SELECT 1 FROM tombstones t
+		    WHERE t.active = TRUE
+		      AND t.severity IN ('hide', 'reject', 'local_only')
+		      AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		      AND t.effective_at <= NOW()
+		      AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
+		      AND (
+		        (t.target_type = 'release' AND t.target_id = c.release_id)
+		        OR (t.target_type = 'manifest' AND t.target_id = rm.manifest_id)
+		        OR (t.target_type = 'event' AND t.target_id IN (source.source_event_id, manifest_source.source_event_id))
+		        OR (t.target_type = 'node' AND t.target_id IN (source.source_node_id, manifest_source.author_node_id))
+		        OR (t.target_type = 'pool_member' AND t.target_id IN (source.source_node_id, manifest_source.author_node_id))
 		      )
 		  )`+ttlClause+`
+		  ORDER BY source.trust_score DESC, manifest_source.updated_at DESC
 		  LIMIT 1`, args...).Scan(&manifestID, &payload, &nzbSHA, &sourceEventID)
 	if err == nil {
 		if matchesNZBSHA256(payload, nzbSHA) {
@@ -137,56 +144,64 @@ func (s *Store) GetFederatedNZBSHA256ByReleaseID(ctx context.Context, releaseID 
 		SELECT COALESCE(rm.nzb_sha256, '')
 		FROM resolution_manifests rm
 		JOIN federated_release_cards card ON card.manifest_id = rm.manifest_id
+		JOIN federated_release_sources source ON source.release_id = card.release_id
+		  AND COALESCE(source.manifest_id, '') = rm.manifest_id
+		  AND source.resolvable = TRUE
+		JOIN federated_manifest_sources advertised ON advertised.manifest_id = rm.manifest_id
+		  AND advertised.release_id = source.release_id
+		  AND advertised.source_node_id = source.source_node_id
+		  AND advertised.pool_id = source.pool_id
+		  AND advertised.advertised = TRUE
+		JOIN resolution_manifest_events manifest_source ON manifest_source.manifest_id = rm.manifest_id
+		  AND manifest_source.pool_id = source.pool_id
+		JOIN federation_events manifest_event ON manifest_event.event_id = manifest_source.source_event_id
+		  AND manifest_event.event_type = 'ResolutionManifest'
+		  AND manifest_event.validation_status = 'accepted'
+		  AND manifest_event.body_json->>'manifest_id' = rm.manifest_id
+		  AND manifest_event.body_json->>'release_id' = card.release_id
+		  AND manifest_event.pool_ids = jsonb_build_array(source.pool_id)
+		JOIN federation_nodes node ON node.node_id = source.source_node_id
+		JOIN trust_pools pool ON pool.pool_id = source.pool_id AND pool.enabled = TRUE
+		JOIN pool_members member ON member.pool_id = source.pool_id
+		  AND member.node_id = source.source_node_id AND member.status = 'active'
+		JOIN federation_nodes manifest_author ON manifest_author.node_id = manifest_source.author_node_id
+		  AND manifest_author.node_id = manifest_event.author_node_id
+		JOIN pool_members manifest_member ON manifest_member.pool_id = source.pool_id
+		  AND manifest_member.node_id = manifest_source.author_node_id AND manifest_member.status = 'active'
 		WHERE card.release_id = $1
 		  AND rm.validation_status = 'accepted'
 		  AND rm.cache_integrity_status <> 'failed'
 		  AND rm.generated_nzb IS NOT NULL
 		  AND rm.nzb_sha256 IS NOT NULL
-		  AND rm.source_event_id IS NOT NULL
-		  AND EXISTS (
-		    SELECT 1
-		    FROM federated_release_sources source
-		    JOIN federation_nodes node ON node.node_id = source.source_node_id
-		    JOIN trust_pools pool ON pool.pool_id = source.pool_id
-		      AND pool.enabled = TRUE
-		    JOIN pool_members member ON member.pool_id = source.pool_id
-		      AND member.node_id = source.source_node_id
-		      AND member.status = 'active'
-		    JOIN federation_nodes manifest_author ON manifest_author.node_id = rm.source_node_id
-		    JOIN pool_members manifest_member ON manifest_member.pool_id = source.pool_id
-		      AND manifest_member.node_id = rm.source_node_id
-		      AND manifest_member.status = 'active'
-		    WHERE source.release_id = card.release_id
-		      AND COALESCE(source.manifest_id, '') = rm.manifest_id
-		      AND node.status NOT IN ('blocked', 'forked')
-		      AND manifest_author.status NOT IN ('blocked', 'forked')
-		      AND (pool.min_node_trust_score <= 0 OR node.local_trust_score >= pool.min_node_trust_score)
-		      AND (pool.min_node_trust_score <= 0 OR manifest_author.local_trust_score >= pool.min_node_trust_score)
-		      AND (member.role = 'admin' OR member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])
-		      AND (manifest_member.role = 'admin' OR manifest_member.allowed_capabilities ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
-		      AND NOT EXISTS (
-		        SELECT 1 FROM federated_release_publication_states ps
-		        WHERE ps.release_id = source.release_id
-		          AND ps.source_node_id = source.source_node_id
-		          AND ps.pool_id = source.pool_id
-		          AND ps.state = 'withdrawn'
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM tombstones t
-		        WHERE t.active = TRUE
-		          AND t.severity IN ('hide','reject','local_only')
-		          AND t.effective_at <= NOW()
-		          AND (t.expires_at IS NULL OR t.expires_at > NOW())
-		          AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
-		          AND (
-		            (t.target_type = 'release' AND t.target_id = card.release_id)
-		            OR (t.target_type = 'manifest' AND t.target_id = rm.manifest_id)
-		            OR (t.target_type = 'event' AND t.target_id IN (source.source_event_id, rm.source_event_id))
-		            OR (t.target_type = 'node' AND t.target_id IN (source.source_node_id, rm.source_node_id))
-		            OR (t.target_type = 'pool_member' AND t.target_id IN (source.source_node_id, rm.source_node_id))
-		          )
+		  AND node.status NOT IN ('blocked', 'forked')
+		  AND manifest_author.status NOT IN ('blocked', 'forked')
+		  AND (pool.min_node_trust_score <= 0 OR node.local_trust_score >= pool.min_node_trust_score)
+		  AND (pool.min_node_trust_score <= 0 OR manifest_author.local_trust_score >= pool.min_node_trust_score)
+		  AND (member.role = 'admin' OR COALESCE(member.allowed_capabilities, '[]'::jsonb) ?| ARRAY['scanner','indexer','release_publisher'])
+		  AND (manifest_member.role = 'admin' OR COALESCE(manifest_member.allowed_capabilities, '[]'::jsonb) ?| ARRAY['manifest_builder','manifest_cache','release_publisher'])
+		  AND NOT EXISTS (
+		    SELECT 1 FROM federated_release_publication_states ps
+		    WHERE ps.release_id = source.release_id
+		      AND ps.source_node_id = source.source_node_id
+		      AND ps.pool_id = source.pool_id
+		      AND ps.state = 'withdrawn'
+		  )
+		  AND NOT EXISTS (
+		    SELECT 1 FROM tombstones t
+		    WHERE t.active = TRUE
+		      AND t.severity IN ('hide','reject','local_only')
+		      AND t.effective_at <= NOW()
+		      AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		      AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
+		      AND (
+		        (t.target_type = 'release' AND t.target_id = card.release_id)
+		        OR (t.target_type = 'manifest' AND t.target_id = rm.manifest_id)
+		        OR (t.target_type = 'event' AND t.target_id IN (source.source_event_id, manifest_source.source_event_id))
+		        OR (t.target_type = 'node' AND t.target_id IN (source.source_node_id, manifest_source.author_node_id))
+		        OR (t.target_type = 'pool_member' AND t.target_id IN (source.source_node_id, manifest_source.author_node_id))
 		      )
 		  )`+ttlClause+`
+		ORDER BY source.trust_score DESC, manifest_source.updated_at DESC
 		LIMIT 1`, args...).Scan(&hash)
 	if isNoRows(err) {
 		return "", false, nil
@@ -422,12 +437,8 @@ func (s *Store) AuthorizeFederatedManifestSource(ctx context.Context, source Fed
 	if !exists {
 		return fmt.Errorf("manifest source is no longer advertised or has been suppressed")
 	}
-	servingAuth, err := s.CanAcceptFederationEventForPools(ctx, servingNodeID, []string{source.PoolID}, manifest.Type)
-	if err != nil {
-		return err
-	}
-	if !servingAuth.Allowed {
-		return fmt.Errorf("manifest serving node is not authorized: %s", servingAuth.Reason)
+	if err := s.authorizeFederatedManifestParticipant(ctx, source.PoolID, servingNodeID); err != nil {
+		return fmt.Errorf("manifest serving node is not authorized: %w", err)
 	}
 	if authorNodeID != servingNodeID {
 		cacheAllowed, err := s.PoolMemberHasCapability(ctx, source.PoolID, servingNodeID, []string{capability.ManifestCache})
@@ -438,12 +449,83 @@ func (s *Store) AuthorizeFederatedManifestSource(ctx context.Context, source Fed
 			return fmt.Errorf("manifest serving node is not an authorized cache")
 		}
 	}
-	authorAuth, err := s.CanAcceptFederationEventForPools(ctx, authorNodeID, []string{source.PoolID}, manifest.Type)
-	if err != nil {
-		return err
+	if err := s.authorizeFederatedManifestParticipant(ctx, source.PoolID, authorNodeID); err != nil {
+		return fmt.Errorf("manifest author is not authorized: %w", err)
 	}
-	if !authorAuth.Allowed {
-		return fmt.Errorf("manifest author is not authorized: %s", authorAuth.Reason)
+	return nil
+}
+
+// authorizeFederatedManifestParticipant applies the pool state and capability
+// checks needed by the dedicated manifest-fetch protocol. ResolutionManifest
+// events are fetched directly and are intentionally not required to be enabled
+// in the pool's general relay accepted_event_types policy.
+func (s *Store) authorizeFederatedManifestParticipant(ctx context.Context, poolID, nodeID string) error {
+	var (
+		nodeStatus        string
+		poolEnabled       bool
+		activeMember      bool
+		capabilityAllowed bool
+		trustScore        float64
+		minimumTrust      float64
+	)
+	err := s.federationExecutor(ctx).QueryRowContext(ctx, `
+		SELECT node.status,
+		       pool.enabled,
+		       node.local_trust_score,
+		       pool.min_node_trust_score,
+		       EXISTS (
+		         SELECT 1
+		         FROM pool_members member
+		         WHERE member.pool_id = pool.pool_id
+		           AND member.node_id = node.node_id
+		           AND member.status = 'active'
+		       ),
+		       EXISTS (
+		         SELECT 1
+		         FROM pool_members member
+		         WHERE member.pool_id = pool.pool_id
+		           AND member.node_id = node.node_id
+		           AND member.status = 'active'
+		           AND (
+		             member.role = 'admin'
+		             OR COALESCE(member.allowed_capabilities, '[]'::jsonb)
+		                ?| ARRAY['manifest_builder','manifest_cache','release_publisher']
+		           )
+		       )
+		FROM federation_nodes node
+		CROSS JOIN trust_pools pool
+		WHERE node.node_id = $1
+		  AND pool.pool_id = $2`, strings.TrimSpace(nodeID), strings.TrimSpace(poolID)).Scan(
+		&nodeStatus,
+		&poolEnabled,
+		&trustScore,
+		&minimumTrust,
+		&activeMember,
+		&capabilityAllowed,
+	)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("node or pool is unknown")
+	}
+	if err != nil {
+		return fmt.Errorf("check manifest participant authorization: %w", err)
+	}
+	if nodeStatus == "blocked" {
+		return fmt.Errorf("node_blocked")
+	}
+	if nodeStatus == "forked" {
+		return fmt.Errorf("node_forked")
+	}
+	if !poolEnabled {
+		return fmt.Errorf("pool_disabled")
+	}
+	if !activeMember {
+		return fmt.Errorf("not_pool_member")
+	}
+	if minimumTrust > 0 && trustScore < minimumTrust {
+		return fmt.Errorf("node_trust_below_pool_minimum")
+	}
+	if !capabilityAllowed {
+		return fmt.Errorf("node_capability_not_allowed")
 	}
 	return nil
 }
@@ -532,6 +614,25 @@ func (s *Store) StoreResolutionManifest(ctx context.Context, record ResolutionMa
 		return fmt.Errorf("store resolution manifest: %w", err)
 	}
 	poolID := firstNonBlank(record.PoolID, "pool.local")
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO resolution_manifest_events (
+			manifest_id, pool_id, author_node_id, source_event_id,
+			fetched_from_node_id, verified_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, NULLIF($5, ''), NOW(), NOW())
+		ON CONFLICT (manifest_id, pool_id, author_node_id) DO UPDATE SET
+			source_event_id = EXCLUDED.source_event_id,
+			fetched_from_node_id = COALESCE(EXCLUDED.fetched_from_node_id, resolution_manifest_events.fetched_from_node_id),
+			verified_at = NOW(),
+			updated_at = NOW()`,
+		record.Manifest.ManifestID,
+		poolID,
+		record.SourceNodeID,
+		record.SourceEventID,
+		record.FetchedFromNodeID,
+	); err != nil {
+		return fmt.Errorf("store resolution manifest pool provenance: %w", err)
+	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO federation_validation_tasks (
 			manifest_id, release_id, source_node_id, source_event_id, pool_id,
@@ -699,7 +800,15 @@ func (s *Store) CanFetchResolutionManifestForSource(ctx context.Context, manifes
 		  JOIN resolution_manifests rm ON rm.manifest_id = fs.manifest_id
 		    AND rm.release_id = fs.release_id
 		    AND rm.validation_status = 'accepted'
-		  JOIN federation_events manifest_event ON manifest_event.event_id = rm.source_event_id
+		  JOIN resolution_manifest_events manifest_source ON manifest_source.manifest_id = rm.manifest_id
+		    AND manifest_source.pool_id = fs.pool_id
+		  JOIN federation_events manifest_event ON manifest_event.event_id = manifest_source.source_event_id
+		    AND manifest_event.author_node_id = manifest_source.author_node_id
+		    AND manifest_event.event_type = 'ResolutionManifest'
+		    AND manifest_event.validation_status = 'accepted'
+		    AND manifest_event.body_json->>'manifest_id' = rm.manifest_id
+		    AND manifest_event.body_json->>'release_id' = rm.release_id
+		    AND manifest_event.pool_ids = jsonb_build_array(fs.pool_id)
 		  JOIN trust_pools pool ON pool.pool_id = fs.pool_id AND pool.enabled = TRUE
 		  JOIN federation_nodes source_node ON source_node.node_id = fs.source_node_id
 		  JOIN pool_members source_member ON source_member.pool_id = fs.pool_id
@@ -752,34 +861,51 @@ func (s *Store) CanFetchResolutionManifestForSource(ctx context.Context, manifes
 	return ok, nil
 }
 
-func (s *Store) GetResolutionManifestEvent(ctx context.Context, manifestID string) (*events.SignedEvent, error) {
+func (s *Store) GetResolutionManifestEvent(ctx context.Context, manifestID, poolID string) (*events.SignedEvent, error) {
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("pgindex store is not initialized")
 	}
 	var eventID string
 	_, ttlDays := s.manifestCachePolicy()
 	ttlClause := ""
-	args := []any{strings.TrimSpace(manifestID)}
+	args := []any{strings.TrimSpace(manifestID), strings.TrimSpace(poolID)}
 	if ttlDays > 0 {
-		ttlClause = " AND updated_at >= NOW() - ($2 * INTERVAL '1 day')"
+		ttlClause = " AND manifest.updated_at >= NOW() - ($3 * INTERVAL '1 day')"
 		args = append(args, ttlDays)
 	}
 	err := s.db.QueryRowContext(ctx, `
-		SELECT source_event_id
-		FROM resolution_manifests
-		WHERE manifest_id = $1
-		  AND validation_status = 'accepted'
-		  AND source_event_id IS NOT NULL
+		SELECT manifest_source.source_event_id
+		FROM resolution_manifests manifest
+		JOIN resolution_manifest_events manifest_source
+		  ON manifest_source.manifest_id = manifest.manifest_id
+		 AND manifest_source.pool_id = $2
+		JOIN federation_events event ON event.event_id = manifest_source.source_event_id
+		  AND event.author_node_id = manifest_source.author_node_id
+		  AND event.event_type = 'ResolutionManifest'
+		  AND event.validation_status = 'accepted'
+		  AND event.body_json->>'manifest_id' = manifest.manifest_id
+		  AND event.body_json->>'release_id' = manifest.release_id
+		  AND event.pool_ids = jsonb_build_array(manifest_source.pool_id)
+		WHERE manifest.manifest_id = $1
+		  AND manifest.validation_status = 'accepted'
 		  AND NOT EXISTS (
 		    SELECT 1
 		    FROM tombstones t
 		    WHERE t.active = TRUE
-		      AND t.severity IN ('reject', 'local_only')
+		      AND t.severity IN ('hide', 'reject', 'local_only')
 		      AND (t.expires_at IS NULL OR t.expires_at > NOW())
 		      AND t.effective_at <= NOW()
-		      AND t.target_type = 'manifest'
-		      AND t.target_id = resolution_manifests.manifest_id
-		  )`+ttlClause, args...).Scan(&eventID)
+		      AND (t.pool_id IS NULL OR t.pool_id = manifest_source.pool_id)
+		      AND (
+		        (t.target_type = 'release' AND t.target_id = manifest.release_id)
+		        OR (t.target_type = 'manifest' AND t.target_id = manifest.manifest_id)
+		        OR (t.target_type = 'event' AND t.target_id = manifest_source.source_event_id)
+		        OR (t.target_type = 'node' AND t.target_id = manifest_source.author_node_id)
+		        OR (t.target_type = 'pool_member' AND t.target_id = manifest_source.author_node_id)
+		      )
+		  )`+ttlClause+`
+		ORDER BY manifest_source.updated_at DESC
+		LIMIT 1`, args...).Scan(&eventID)
 	if isNoRows(err) {
 		return nil, nil
 	}

--- a/internal/store/pgindex/federation_pool_authorization_integration_test.go
+++ b/internal/store/pgindex/federation_pool_authorization_integration_test.go
@@ -78,6 +78,19 @@ func TestFederationPoolAuthorizationIntegration(t *testing.T) {
 	if multiple.Allowed || multiple.Reason != "multiple_pools_not_supported" {
 		t.Fatalf("expected v1 multiple-pool rejection, result=%+v", multiple)
 	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federation_nodes SET status = 'blocked' WHERE node_id = $1`, nodeID); err != nil {
+		t.Fatalf("block node: %v", err)
+	}
+	blocked, err := store.CanAcceptFederationEventForPools(ctx, nodeID, []string{poolID}, "ReleaseCard")
+	if err != nil {
+		t.Fatalf("authorize blocked node: %v", err)
+	}
+	if blocked.Allowed || blocked.Reason != "node_blocked" {
+		t.Fatalf("expected blocked node rejection, result=%+v", blocked)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE federation_nodes SET status = 'known' WHERE node_id = $1`, nodeID); err != nil {
+		t.Fatalf("restore node: %v", err)
+	}
 	if _, err := store.DB().ExecContext(ctx, `UPDATE pool_members SET status = 'revoked' WHERE pool_id = $1 AND node_id = $2`, poolID, nodeID); err != nil {
 		t.Fatalf("revoke member: %v", err)
 	}

--- a/internal/store/pgindex/federation_pool_store.go
+++ b/internal/store/pgindex/federation_pool_store.go
@@ -265,6 +265,20 @@ func (s *Store) ProjectFederationPoolEvent(ctx context.Context, event *events.Si
 }
 
 func (s *Store) CanAcceptFederationEventForPools(ctx context.Context, authorNodeID string, poolIDs []string, eventType string) (PoolAuthorizationResult, error) {
+	var nodeStatus string
+	if err := s.federationExecutor(ctx).QueryRowContext(ctx, `
+		SELECT status FROM federation_nodes WHERE node_id = $1`, strings.TrimSpace(authorNodeID)).Scan(&nodeStatus); err != nil {
+		if err == sql.ErrNoRows {
+			return PoolAuthorizationResult{Allowed: false, Reason: "unknown_node"}, nil
+		}
+		return PoolAuthorizationResult{}, err
+	}
+	if nodeStatus == "blocked" {
+		return PoolAuthorizationResult{Allowed: false, Reason: "node_blocked"}, nil
+	}
+	if nodeStatus == "forked" {
+		return PoolAuthorizationResult{Allowed: false, Reason: "node_forked"}, nil
+	}
 	normalizedPools := normalizeStrings(poolIDs)
 	if len(normalizedPools) == 0 {
 		return PoolAuthorizationResult{Allowed: false, Reason: "missing_pool"}, nil

--- a/internal/store/pgindex/federation_releasecard_store.go
+++ b/internal/store/pgindex/federation_releasecard_store.go
@@ -12,6 +12,8 @@ import (
 	"github.com/datallboy/gonzb/internal/gonzbnet/releasecard"
 )
 
+const goNZBNetIndexerSourceKind = "usenet_index"
+
 type FederatedReleaseCardSearchParams struct {
 	Query  string
 	IMDBID string
@@ -53,6 +55,7 @@ func (s *Store) ListGoNZBNetLocalReleaseCandidates(ctx context.Context, limit in
 		limit = 50
 	}
 	summaries, _, err := s.ListPublicIndexerReleases(ctx, PublicIndexerReleaseListParams{
+		SourceKind:  goNZBNetIndexerSourceKind,
 		Limit:       limit,
 		Sort:        "posted_at_desc",
 		ReadyPolicy: policy,

--- a/internal/store/pgindex/federation_releasecard_store.go
+++ b/internal/store/pgindex/federation_releasecard_store.go
@@ -419,13 +419,62 @@ func (s *Store) CanGetFederatedReleaseForPrincipal(ctx context.Context, releaseI
 		SELECT EXISTS (
 		  SELECT 1
 		  FROM federated_release_sources source
+		  JOIN federated_release_cards card ON card.release_id = source.release_id
+		  JOIN federation_events source_event ON source_event.event_id = source.source_event_id
+		  JOIN federation_nodes node ON node.node_id = source.source_node_id
+		  JOIN trust_pools pool ON pool.pool_id = source.pool_id AND pool.enabled = TRUE
+		  JOIN pool_members member ON member.pool_id = source.pool_id
+		    AND member.node_id = source.source_node_id
+		    AND member.status = 'active'
 		  WHERE source.release_id = $1
+		    AND node.status NOT IN ('blocked', 'forked')
+		    AND (pool.min_node_trust_score <= 0 OR node.local_trust_score >= pool.min_node_trust_score)
+		    AND (member.role = 'admin' OR member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])
+		    AND source_event.validation_status = 'accepted'
+		    AND source_event.event_type = 'ReleaseCard'
+		    AND source_event.author_node_id = source.source_node_id
+		    AND source_event.pool_ids @> jsonb_build_array(source.pool_id)
+		    AND card.body_json = source_event.body_json
+		    AND COALESCE(source_event.body_json->>'release_id', '') = source.release_id
+		    AND COALESCE(source_event.body_json->>'manifest_id', '') = COALESCE(source.manifest_id, '')
+		    AND card.title = COALESCE(source_event.body_json->>'title', '')
+		    AND card.normalized_title = COALESCE(source_event.body_json->>'normalized_title', '')
+		    AND card.category_json = COALESCE(source_event.body_json->'category', '[]'::jsonb)
+		    AND card.newznab_categories = COALESCE(source_event.body_json->'newznab_categories', '[]'::jsonb)
+		    AND card.size_bytes IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'size_bytes', '')::bigint
+		    AND card.posted_at IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'posted_at', '')::timestamptz
+		    AND card.groups_json = COALESCE(source_event.body_json->'groups', '[]'::jsonb)
+		    AND card.file_count IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'file_count', '')::integer
+		    AND card.segment_count IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'segment_count', '')::integer
+		    AND COALESCE(card.poster_hash, '') = COALESCE(source_event.body_json->>'poster_hash', '')
+		    AND card.subject_fingerprint = COALESCE(source_event.body_json->>'subject_fingerprint', '')
+		    AND card.file_fingerprint = COALESCE(source_event.body_json->>'file_fingerprint', '')
+		    AND card.media_json = COALESCE(source_event.body_json->'media', '{}'::jsonb)
+		    AND card.quality_json = COALESCE(source_event.body_json->'quality', '{}'::jsonb)
+		    AND card.flags_json = COALESCE(source_event.body_json->'flags', '{}'::jsonb)
+		    AND card.resolution_json = COALESCE(source_event.body_json->'resolution', '{}'::jsonb)
+		    AND card.expires_at IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'expires_at', '')::timestamptz
 		    AND NOT EXISTS (
 		      SELECT 1 FROM federated_release_publication_states ps
 		      WHERE ps.release_id = source.release_id
 		        AND ps.source_node_id = source.source_node_id
 		        AND ps.pool_id = source.pool_id
 		        AND ps.state = 'withdrawn'
+		    )
+		    AND NOT EXISTS (
+		      SELECT 1 FROM tombstones t
+		      WHERE t.active = TRUE
+		        AND t.severity IN ('hide','reject','local_only')
+		        AND t.effective_at <= NOW()
+		        AND (t.expires_at IS NULL OR t.expires_at > NOW())
+		        AND (t.pool_id IS NULL OR t.pool_id = source.pool_id)
+		        AND (
+		          (t.target_type = 'release' AND t.target_id = source.release_id)
+		          OR (t.target_type = 'manifest' AND t.target_id = COALESCE(source.manifest_id, ''))
+		          OR (t.target_type = 'event' AND t.target_id = source.source_event_id)
+		          OR (t.target_type = 'node' AND t.target_id = source.source_node_id)
+		          OR (t.target_type = 'pool_member' AND t.target_id = source.source_node_id)
+		        )
 		    )
 		    AND source.pool_id IN (
 		      SELECT pool_id
@@ -550,6 +599,34 @@ func (s *Store) SearchFederatedReleaseCards(ctx context.Context, params Federate
 		"c.status = 'accepted'",
 		"(c.expires_at IS NULL OR c.expires_at > NOW())",
 		"s.trust_score > 0",
+		"source_node.status NOT IN ('blocked', 'forked')",
+		"source_pool.enabled = TRUE",
+		"(source_pool.min_node_trust_score <= 0 OR source_node.local_trust_score >= source_pool.min_node_trust_score)",
+		"(source_member.role = 'admin' OR source_member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])",
+		"source_event.validation_status = 'accepted'",
+		"source_event.event_type = 'ReleaseCard'",
+		"source_event.author_node_id = s.source_node_id",
+		"source_event.pool_ids @> jsonb_build_array(s.pool_id)",
+		"c.body_json = source_event.body_json",
+		"COALESCE(source_event.body_json->>'release_id', '') = s.release_id",
+		"COALESCE(source_event.body_json->>'manifest_id', '') = COALESCE(s.manifest_id, '')",
+		"c.title = COALESCE(source_event.body_json->>'title', '')",
+		"c.normalized_title = COALESCE(source_event.body_json->>'normalized_title', '')",
+		"c.category_json = COALESCE(source_event.body_json->'category', '[]'::jsonb)",
+		"c.newznab_categories = COALESCE(source_event.body_json->'newznab_categories', '[]'::jsonb)",
+		"c.size_bytes IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'size_bytes', '')::bigint",
+		"c.posted_at IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'posted_at', '')::timestamptz",
+		"c.groups_json = COALESCE(source_event.body_json->'groups', '[]'::jsonb)",
+		"c.file_count IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'file_count', '')::integer",
+		"c.segment_count IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'segment_count', '')::integer",
+		"COALESCE(c.poster_hash, '') = COALESCE(source_event.body_json->>'poster_hash', '')",
+		"c.subject_fingerprint = COALESCE(source_event.body_json->>'subject_fingerprint', '')",
+		"c.file_fingerprint = COALESCE(source_event.body_json->>'file_fingerprint', '')",
+		"c.media_json = COALESCE(source_event.body_json->'media', '{}'::jsonb)",
+		"c.quality_json = COALESCE(source_event.body_json->'quality', '{}'::jsonb)",
+		"c.flags_json = COALESCE(source_event.body_json->'flags', '{}'::jsonb)",
+		"c.resolution_json = COALESCE(source_event.body_json->'resolution', '{}'::jsonb)",
+		"c.expires_at IS NOT DISTINCT FROM NULLIF(source_event.body_json->>'expires_at', '')::timestamptz",
 		`NOT EXISTS (
 			SELECT 1
 			FROM federated_release_publication_states ps
@@ -568,6 +645,9 @@ func (s *Store) SearchFederatedReleaseCards(ctx context.Context, params Federate
 			  AND (
 			    (t.target_type = 'release' AND t.target_id = c.release_id)
 			    OR (t.target_type = 'manifest' AND t.target_id = COALESCE(c.manifest_id, ''))
+			    OR (t.target_type = 'event' AND t.target_id = s.source_event_id)
+			    OR (t.target_type = 'node' AND t.target_id = s.source_node_id)
+			    OR (t.target_type = 'pool_member' AND t.target_id = s.source_node_id)
 			  )
 			  AND (t.pool_id IS NULL OR t.pool_id = s.pool_id)
 		)`,
@@ -598,14 +678,44 @@ func (s *Store) SearchFederatedReleaseCards(ctx context.Context, params Federate
 
 	query := fmt.Sprintf(`
 		WITH source_counts AS (
-			SELECT release_id, LEAST(1.0, COUNT(*)::double precision / 3.0) AS quorum_score
-			FROM federated_release_sources
+			SELECT counted.release_id, LEAST(1.0, COUNT(DISTINCT (counted.source_node_id, counted.pool_id))::double precision / 3.0) AS quorum_score
+			FROM federated_release_sources counted
+			JOIN federation_nodes counted_node ON counted_node.node_id = counted.source_node_id
+			JOIN trust_pools counted_pool ON counted_pool.pool_id = counted.pool_id AND counted_pool.enabled = TRUE
+			JOIN pool_members counted_member ON counted_member.pool_id = counted.pool_id
+			 AND counted_member.node_id = counted.source_node_id
+			 AND counted_member.status = 'active'
 			WHERE EXISTS (
 				SELECT 1
 				FROM jsonb_array_elements_text($1::jsonb) pools(pool_id)
-				WHERE pools.pool_id = federated_release_sources.pool_id
+				WHERE pools.pool_id = counted.pool_id
 			)
-			GROUP BY release_id
+			  AND counted_node.status NOT IN ('blocked', 'forked')
+			  AND (counted_pool.min_node_trust_score <= 0 OR counted_node.local_trust_score >= counted_pool.min_node_trust_score)
+			  AND (counted_member.role = 'admin' OR counted_member.allowed_capabilities ?| ARRAY['scanner','indexer','release_publisher'])
+			  AND NOT EXISTS (
+			    SELECT 1 FROM federated_release_publication_states ps
+			    WHERE ps.release_id = counted.release_id
+			      AND ps.source_node_id = counted.source_node_id
+			      AND ps.pool_id = counted.pool_id
+			      AND ps.state = 'withdrawn'
+			  )
+			  AND NOT EXISTS (
+			    SELECT 1 FROM tombstones t
+			    WHERE t.active = TRUE
+			      AND t.severity IN ('hide','reject','local_only')
+			      AND t.effective_at <= NOW()
+			      AND (t.expires_at IS NULL OR t.expires_at > NOW())
+			      AND (t.pool_id IS NULL OR t.pool_id = counted.pool_id)
+			      AND (
+			        (t.target_type = 'release' AND t.target_id = counted.release_id)
+			        OR (t.target_type = 'manifest' AND t.target_id = COALESCE(counted.manifest_id, ''))
+			        OR (t.target_type = 'event' AND t.target_id = counted.source_event_id)
+			        OR (t.target_type = 'node' AND t.target_id = counted.source_node_id)
+			        OR (t.target_type = 'pool_member' AND t.target_id = counted.source_node_id)
+			      )
+			  )
+			GROUP BY counted.release_id
 		),
 		ranked AS (
 			SELECT
@@ -654,6 +764,12 @@ func (s *Store) SearchFederatedReleaseCards(ctx context.Context, params Federate
 				) AS source_rank
 			FROM federated_release_cards c
 			JOIN federated_release_sources s ON s.release_id = c.release_id
+			JOIN federation_events source_event ON source_event.event_id = s.source_event_id
+			JOIN federation_nodes source_node ON source_node.node_id = s.source_node_id
+			JOIN trust_pools source_pool ON source_pool.pool_id = s.pool_id
+			JOIN pool_members source_member ON source_member.pool_id = s.pool_id
+			 AND source_member.node_id = s.source_node_id
+			 AND source_member.status = 'active'
 			JOIN source_counts sc ON sc.release_id = c.release_id
 			WHERE %s
 		)

--- a/internal/store/pgindex/federation_tombstone_store.go
+++ b/internal/store/pgindex/federation_tombstone_store.go
@@ -96,11 +96,6 @@ func (s *Store) ProjectTombstone(ctx context.Context, projection TombstoneProjec
 	if err := upsertTombstoneProjection(ctx, tx, item, eventID, active, approvalCount, approvalsRequired, effectiveAt.UTC(), expiresAt); err != nil {
 		return err
 	}
-	if active {
-		if err := applyActiveTombstone(ctx, tx, item); err != nil {
-			return err
-		}
-	}
 	return commit()
 }
 
@@ -255,58 +250,6 @@ func upsertTombstoneProjection(ctx context.Context, tx tombstoneTx, item moderat
 		expiresAt,
 	); err != nil {
 		return fmt.Errorf("insert tombstone projection: %w", err)
-	}
-	return nil
-}
-
-func applyActiveTombstone(ctx context.Context, tx tombstoneTx, item moderation.Tombstone) error {
-	severity := strings.TrimSpace(item.Severity)
-	if severity == moderation.SeverityWarn {
-		return nil
-	}
-	switch strings.TrimSpace(item.TargetType) {
-	case moderation.TargetRelease:
-		status := "hidden"
-		if severity == moderation.SeverityReject || severity == moderation.SeverityLocalOnly {
-			status = "rejected"
-		}
-		if _, err := tx.ExecContext(ctx, `
-			UPDATE federated_release_cards
-			SET status = $2,
-			    updated_at = NOW()
-			WHERE release_id = $1`,
-			item.TargetID,
-			status,
-		); err != nil {
-			return fmt.Errorf("apply release tombstone: %w", err)
-		}
-		if severity == moderation.SeverityReject || severity == moderation.SeverityLocalOnly {
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE resolution_manifests
-				SET validation_status = 'invalidated',
-				    rejection_reason = 'tombstoned_release',
-				    generated_nzb = NULL,
-				    updated_at = NOW()
-				WHERE release_id = $1`,
-				item.TargetID,
-			); err != nil {
-				return fmt.Errorf("invalidate release manifests: %w", err)
-			}
-		}
-	case moderation.TargetManifest:
-		if severity == moderation.SeverityReject || severity == moderation.SeverityLocalOnly {
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE resolution_manifests
-				SET validation_status = 'invalidated',
-				    rejection_reason = 'tombstoned_manifest',
-				    generated_nzb = NULL,
-				    updated_at = NOW()
-				WHERE manifest_id = $1`,
-				item.TargetID,
-			); err != nil {
-				return fmt.Errorf("invalidate manifest tombstone: %w", err)
-			}
-		}
 	}
 	return nil
 }

--- a/internal/store/pgindex/migrations/038_gonzbnet_integrity_hardening.up.sql
+++ b/internal/store/pgindex/migrations/038_gonzbnet_integrity_hardening.up.sql
@@ -1,0 +1,22 @@
+ALTER TABLE resolution_manifests
+  ADD COLUMN IF NOT EXISTS fetched_from_node_id TEXT REFERENCES federation_nodes(node_id),
+  ADD COLUMN IF NOT EXISTS cache_integrity_status TEXT NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS cache_integrity_failed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS cache_integrity_error TEXT;
+
+ALTER TABLE resolution_manifests
+  DROP CONSTRAINT IF EXISTS resolution_manifests_cache_integrity_status_check;
+
+ALTER TABLE resolution_manifests
+  ADD CONSTRAINT resolution_manifests_cache_integrity_status_check
+  CHECK (cache_integrity_status IN ('unknown', 'verified', 'failed'));
+
+CREATE INDEX IF NOT EXISTS idx_federation_nodes_status_node
+  ON federation_nodes(status, node_id);
+
+CREATE INDEX IF NOT EXISTS idx_tombstones_active_target_pool
+  ON tombstones(target_type, target_id, pool_id)
+  WHERE active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_release_publication_state_effective
+  ON federated_release_publication_states(pool_id, source_node_id, release_id, state);

--- a/internal/store/pgindex/migrations/039_gonzbnet_manifest_pool_provenance.up.sql
+++ b/internal/store/pgindex/migrations/039_gonzbnet_manifest_pool_provenance.up.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS resolution_manifest_events (
+  manifest_id TEXT NOT NULL REFERENCES resolution_manifests(manifest_id) ON DELETE CASCADE,
+  pool_id TEXT NOT NULL REFERENCES trust_pools(pool_id),
+  author_node_id TEXT NOT NULL REFERENCES federation_nodes(node_id),
+  source_event_id TEXT NOT NULL UNIQUE REFERENCES federation_events(event_id),
+  fetched_from_node_id TEXT REFERENCES federation_nodes(node_id),
+  verified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (manifest_id, pool_id, author_node_id)
+);
+
+INSERT INTO resolution_manifest_events (
+  manifest_id,
+  pool_id,
+  author_node_id,
+  source_event_id,
+  fetched_from_node_id,
+  verified_at,
+  updated_at
+)
+SELECT DISTINCT ON (manifest.manifest_id, pool_id.value, event.author_node_id)
+       manifest.manifest_id,
+       pool_id.value,
+       event.author_node_id,
+       event.event_id,
+       manifest.fetched_from_node_id,
+       COALESCE(manifest.verified_at, event.received_at),
+       NOW()
+FROM resolution_manifests manifest
+JOIN federation_events event
+  ON event.event_type = 'ResolutionManifest'
+ AND event.validation_status = 'accepted'
+ AND event.body_json->>'manifest_id' = manifest.manifest_id
+ AND event.body_json->>'release_id' = manifest.release_id
+CROSS JOIN LATERAL jsonb_array_elements_text(event.pool_ids) AS pool_id(value)
+JOIN trust_pools pool ON pool.pool_id = pool_id.value
+WHERE jsonb_array_length(event.pool_ids) = 1
+ORDER BY manifest.manifest_id, pool_id.value, event.author_node_id, event.created_at DESC, event.event_id DESC
+ON CONFLICT (manifest_id, pool_id, author_node_id) DO UPDATE SET
+  source_event_id = EXCLUDED.source_event_id,
+  fetched_from_node_id = EXCLUDED.fetched_from_node_id,
+  verified_at = EXCLUDED.verified_at,
+  updated_at = NOW();
+
+CREATE INDEX IF NOT EXISTS idx_resolution_manifest_events_pool_manifest
+  ON resolution_manifest_events(pool_id, manifest_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_federation_events_resolution_manifest_id
+  ON federation_events ((body_json->>'manifest_id'), created_at DESC)
+  WHERE event_type = 'ResolutionManifest' AND validation_status = 'accepted';

--- a/internal/store/pgindex/public_release_reads.go
+++ b/internal/store/pgindex/public_release_reads.go
@@ -13,6 +13,7 @@ import (
 
 type PublicIndexerReleaseListParams struct {
 	Query             string
+	SourceKind        string
 	Limit             int
 	Offset            int
 	Sort              string
@@ -231,6 +232,9 @@ func buildPublicIndexerFilterSQL(params PublicIndexerReleaseListParams) (string,
 		arg += len(values)
 	}
 
+	if sourceKind := strings.TrimSpace(params.SourceKind); sourceKind != "" {
+		add(fmt.Sprintf("r.source_kind = $%d", arg), sourceKind)
+	}
 	if query := strings.TrimSpace(params.Query); query != "" {
 		add(fmt.Sprintf("r.search_title ILIKE '%%' || $%d || '%%'", arg), query)
 	}

--- a/internal/store/pgindex/uploader_catalog_store_test.go
+++ b/internal/store/pgindex/uploader_catalog_store_test.go
@@ -51,6 +51,13 @@ func TestUploaderCatalogProjectionAppearsInPublicAndAdminReleases(t *testing.T) 
 	if total != 1 || len(public) != 1 || public[0].ReleaseID != submission.ReleaseID || public[0].SourceKind != uploaderCatalogSourceKind {
 		t.Fatalf("unexpected public projection: total=%d items=%+v", total, public)
 	}
+	federationCandidates, err := store.ListGoNZBNetLocalReleaseCandidates(t.Context(), 10, DefaultReleaseReadyPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(federationCandidates) != 0 {
+		t.Fatalf("uploader approval leaked into automatic GoNZBNet publication candidates: %+v", federationCandidates)
+	}
 	publicDetail, err := store.GetPublicIndexerReleaseDetail(t.Context(), submission.ReleaseID)
 	if err != nil {
 		t.Fatal(err)

--- a/ui/src/modules/admin/AdminGoNZBNetPage.tsx
+++ b/ui/src/modules/admin/AdminGoNZBNetPage.tsx
@@ -37,6 +37,7 @@ import {
   getGoNZBNetPeerDeliveryDiagnostics,
   getGoNZBNetPeerDiagnostics,
   getGoNZBNetRejectedEventDiagnostics,
+  getGoNZBNetReleaseLedger,
   getGoNZBNetReleaseSourceDiagnostics,
   getGoNZBNetReputationDiagnostics,
   getGoNZBNetRolePoolAccess,
@@ -94,6 +95,7 @@ import type {
   GoNZBNetPoolMember,
   GoNZBNetRejectedEventDiagnostic,
   GoNZBNetRejectedEventSummary,
+  GoNZBNetReleaseLedgerItem,
   GoNZBNetReleaseSourceDiagnostic,
   GoNZBNetReputationDiagnostic,
   GoNZBNetRolePoolAccess,
@@ -564,11 +566,21 @@ export function AdminGoNZBNetPage() {
   const [plan, setPlan] = useState<GoNZBNetCoveragePlan | null>(null)
   const [peerDiagnostics, setPeerDiagnostics] = useState<GoNZBNetPeerDiagnostic[]>([])
   const [eventDiagnostics, setEventDiagnostics] = useState<GoNZBNetEventDiagnostic[]>([])
+  const [eventNodeID, setEventNodeID] = useState('')
+  const [eventType, setEventType] = useState('')
+  const [eventValidationStatus, setEventValidationStatus] = useState('')
+  const [eventProjected, setEventProjected] = useState('')
+  const [eventTombstoned, setEventTombstoned] = useState('')
   const [rejectedDiagnostics, setRejectedDiagnostics] = useState<GoNZBNetRejectedEventDiagnostic[]>([])
   const [rejectedSummary, setRejectedSummary] = useState<GoNZBNetRejectedEventSummary[]>([])
   const [deliveryDiagnostics, setDeliveryDiagnostics] = useState<GoNZBNetPeerDeliveryDiagnostic[]>([])
   const [validationTaskDiagnostics, setValidationTaskDiagnostics] = useState<GoNZBNetValidationTaskDiagnostic[]>([])
   const [releaseSourceDiagnostics, setReleaseSourceDiagnostics] = useState<GoNZBNetReleaseSourceDiagnostic[]>([])
+  const [releaseLedger, setReleaseLedger] = useState<GoNZBNetReleaseLedgerItem[]>([])
+  const [releaseLedgerNextCursor, setReleaseLedgerNextCursor] = useState('')
+  const [releaseLedgerNodeID, setReleaseLedgerNodeID] = useState('')
+  const [releaseLedgerReleaseID, setReleaseLedgerReleaseID] = useState('')
+  const [releaseLedgerState, setReleaseLedgerState] = useState('')
   const [manifestSourceDiagnostics, setManifestSourceDiagnostics] = useState<GoNZBNetManifestSourceDiagnostic[]>([])
   const [healthDiagnostics, setHealthDiagnostics] = useState<GoNZBNetHealthAttestationDiagnostic[]>([])
   const [reputationDiagnostics, setReputationDiagnostics] = useState<GoNZBNetReputationDiagnostic[]>([])
@@ -646,6 +658,42 @@ export function AdminGoNZBNetPage() {
     }, { replace: true })
   }
 
+  async function loadReleaseLedger(append = false) {
+    try {
+      const page = await getGoNZBNetReleaseLedger({
+        pool_id: effectivePoolID,
+        node_id: releaseLedgerNodeID.trim() || undefined,
+        release_id: releaseLedgerReleaseID.trim() || undefined,
+        state: releaseLedgerState || undefined,
+        cursor: append ? releaseLedgerNextCursor || undefined : undefined,
+        limit: 100,
+      })
+      setReleaseLedger((current) => append ? [...current, ...(page.items ?? [])] : (page.items ?? []))
+      setReleaseLedgerNextCursor(page.next_cursor ?? '')
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load release ledger')
+    }
+  }
+
+  async function loadEventDiagnostics() {
+    try {
+      const response = await getGoNZBNetEventDiagnostics({
+        pool_id: effectivePoolID,
+        node_id: eventNodeID.trim() || undefined,
+        event_type: eventType.trim() || undefined,
+        validation_status: eventValidationStatus || undefined,
+        projected: eventProjected === '' ? undefined : eventProjected === 'true',
+        tombstoned: eventTombstoned === '' ? undefined : eventTombstoned === 'true',
+        limit: 100,
+      })
+      setEventDiagnostics(response.items ?? [])
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load event diagnostics')
+    }
+  }
+
   const refresh = useCallback(async () => {
     setLoading(true)
     try {
@@ -671,6 +719,7 @@ export function AdminGoNZBNetPage() {
         nextRolePoolAccess,
         nextTombstones,
         nextReleaseSources,
+        nextReleaseLedger,
         nextManifestSources,
         nextHealth,
         nextReputation,
@@ -692,7 +741,7 @@ export function AdminGoNZBNetPage() {
           getGoNZBNetCoverageSuggestions({ pool_id: effectivePoolID, limit: 25 }),
           getGoNZBNetCoveragePlan({ pool_id: effectivePoolID, limit: 25 }),
           getGoNZBNetPeerDiagnostics(100),
-          getGoNZBNetEventDiagnostics(100),
+          getGoNZBNetEventDiagnostics({ pool_id: effectivePoolID, limit: 100 }),
           getGoNZBNetRejectedEventDiagnostics(100),
           getGoNZBNetPeerDeliveryDiagnostics(100),
           getGoNZBNetValidationTaskDiagnostics(100),
@@ -703,6 +752,7 @@ export function AdminGoNZBNetPage() {
           getGoNZBNetRolePoolAccess(effectivePoolID),
           getGoNZBNetTombstones(false).catch(() => ({ items: [], count: 0 })),
           getGoNZBNetReleaseSourceDiagnostics(effectivePoolID, 100),
+          getGoNZBNetReleaseLedger({ pool_id: effectivePoolID, limit: 100 }),
           getGoNZBNetManifestSourceDiagnostics(effectivePoolID, 100),
           getGoNZBNetHealthDiagnostics(effectivePoolID, 100),
           getGoNZBNetReputationDiagnostics(100),
@@ -735,6 +785,8 @@ export function AdminGoNZBNetPage() {
       setRolePoolAccess(nextRolePoolAccess.items ?? [])
       setTombstones(nextTombstones.items ?? [])
       setReleaseSourceDiagnostics(nextReleaseSources.items ?? [])
+      setReleaseLedger(nextReleaseLedger.items ?? [])
+      setReleaseLedgerNextCursor(nextReleaseLedger.next_cursor ?? '')
       setManifestSourceDiagnostics(nextManifestSources.items ?? [])
       setHealthDiagnostics(nextHealth.items ?? [])
       setReputationDiagnostics(nextReputation.items ?? [])
@@ -1424,6 +1476,7 @@ export function AdminGoNZBNetPage() {
         <StatCard label="Events accepted" value={formatNumber(protocolMetrics?.counters.gonzbnet_events_accepted_total ?? 0)} detail={`${formatNumber(protocolMetrics?.counters.gonzbnet_release_cards_projected_total ?? 0)} release cards`} />
         <StatCard label="Peer failures" value={formatNumber(protocolMetrics?.counters.gonzbnet_peer_failures_total ?? 0)} detail={`${peerSyncAverage.toFixed(3)}s average sync`} />
         <StatCard label="Manifest requests" value={formatNumber(protocolMetrics?.counters.gonzbnet_manifest_requests_total ?? 0)} detail={`${formatNumber(protocolMetrics?.counters.gonzbnet_manifest_request_failures_total ?? 0)} failures`} />
+        <StatCard label="Cache integrity" value={formatNumber(protocolMetrics?.counters.gonzbnet_manifest_cache_integrity_failures_total ?? 0)} detail="checksum failures" />
         <StatCard label="Health attestations" value={formatNumber(protocolMetrics?.counters.gonzbnet_health_attestations_total ?? 0)} detail="projected" />
         <StatCard label="Active tombstones" value={formatNumber(protocolMetrics?.gauges.gonzbnet_tombstones_active_total ?? 0)} detail="current database state" />
         <StatCard label="Evidence peer hits" value={formatNumber(protocolMetrics?.counters.gonzbnet_binary_evidence_yenc_hits_total ?? 0)} detail={`${formatNumber(protocolMetrics?.counters.gonzbnet_binary_evidence_peer_requests_total ?? 0)} requests`} />
@@ -2136,8 +2189,118 @@ export function AdminGoNZBNetPage() {
         </table>
       </SectionTable>
 
+      <SectionTable title={`Release integrity ledger: ${effectivePoolID}`} count={releaseLedger.length}>
+        <div className="stack">
+          <p className="muted-copy">This is the local node's observed pool history. Signed metadata remains immutable; publication state, membership, blocks, and tombstones determine the effective state.</p>
+          <div className="toolbar-grid">
+            <label className="field">
+              <span>Source node</span>
+              <input className="table-input" placeholder="node_id" value={releaseLedgerNodeID} onChange={(event) => setReleaseLedgerNodeID(event.target.value)} />
+            </label>
+            <label className="field">
+              <span>Release</span>
+              <input className="table-input" placeholder="release_id" value={releaseLedgerReleaseID} onChange={(event) => setReleaseLedgerReleaseID(event.target.value)} />
+            </label>
+            <label className="field">
+              <span>Effective state</span>
+              <select className="table-input" value={releaseLedgerState} onChange={(event) => setReleaseLedgerState(event.target.value)}>
+                <option value="">All states</option>
+                <option value="active">Active</option>
+                <option value="withdrawn">Withdrawn</option>
+                <option value="blocked">Blocked</option>
+                <option value="revoked">Revoked</option>
+                <option value="tombstoned">Tombstoned</option>
+                <option value="projection_mismatch">Projection mismatch</option>
+              </select>
+            </label>
+            <button className="secondary-button align-end" type="button" onClick={() => void loadReleaseLedger(false)}>Apply filters</button>
+          </div>
+          <table className="data-table data-table--compact">
+            <thead>
+              <tr>
+                <th>Release</th>
+                <th>Source / pool</th>
+                <th>Publication</th>
+                <th>Moderation</th>
+                <th>Integrity</th>
+                <th>Effective</th>
+                <th>Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {releaseLedger.map((item) => (
+                <tr key={`${item.release_id}-${item.source_node_id}-${item.pool_id}`}>
+                  <td className="breakable-value" title={item.release_id}>
+                    {label(item.signed_title || item.projected_title, shortID(item.release_id))}
+                    <div className="muted-copy mono-cell">{shortID(item.release_id)}</div>
+                    <div className="muted-copy mono-cell" title={item.manifest_id}>{shortID(item.manifest_id)}</div>
+                  </td>
+                  <td className="mono-cell breakable-value" title={item.source_node_id}>
+                    {shortID(item.source_node_id)}
+                    <div className="muted-copy">{item.pool_id}</div>
+                    <div className="muted-copy">{item.node_status} / {item.membership_status}</div>
+                  </td>
+                  <td>
+                    <span className="status-pill status-pill--table">{item.publication_state}</span>
+                    {item.publication_reason ? <div className="muted-copy breakable-value">{item.publication_reason}</div> : null}
+                    {item.publication_changed_at ? <div className="muted-copy">{formatDateTime(item.publication_changed_at)}</div> : null}
+                  </td>
+                  <td>
+                    {item.tombstone_severity ? <span className="status-pill status-pill--table">{item.tombstone_severity}</span> : 'none'}
+                    {item.tombstone_target_type ? <div className="muted-copy">{item.tombstone_target_type}: {shortID(item.tombstone_target_id)}</div> : null}
+                  </td>
+                  <td>
+                    <span className="status-pill status-pill--table">{item.projection_matches_signed_event ? 'verified' : 'mismatch'}</span>
+                    <div className="muted-copy mono-cell" title={item.source_event_id}>{shortID(item.source_event_id)}</div>
+                  </td>
+                  <td><span className="status-pill status-pill--table">{item.effective_state}</span></td>
+                  <td>{formatDateTime(item.last_seen_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {releaseLedgerNextCursor ? <button className="secondary-button align-end" type="button" onClick={() => void loadReleaseLedger(true)}>Load more</button> : null}
+        </div>
+      </SectionTable>
+
       <SectionTable title="Event diagnostics" count={eventDiagnostics.length}>
-        <table className="data-table data-table--compact">
+        <div className="stack">
+          <div className="toolbar-grid">
+            <label className="field">
+              <span>Author node</span>
+              <input className="table-input" placeholder="node_id" value={eventNodeID} onChange={(event) => setEventNodeID(event.target.value)} />
+            </label>
+            <label className="field">
+              <span>Event type</span>
+              <input className="table-input" placeholder="ReleaseCard" value={eventType} onChange={(event) => setEventType(event.target.value)} />
+            </label>
+            <label className="field">
+              <span>Validation</span>
+              <select className="table-input" value={eventValidationStatus} onChange={(event) => setEventValidationStatus(event.target.value)}>
+                <option value="">All</option>
+                <option value="accepted">Accepted</option>
+                <option value="rejected">Rejected</option>
+              </select>
+            </label>
+            <label className="field">
+              <span>Projected</span>
+              <select className="table-input" value={eventProjected} onChange={(event) => setEventProjected(event.target.value)}>
+                <option value="">All</option>
+                <option value="true">Yes</option>
+                <option value="false">No</option>
+              </select>
+            </label>
+            <label className="field">
+              <span>Tombstoned</span>
+              <select className="table-input" value={eventTombstoned} onChange={(event) => setEventTombstoned(event.target.value)}>
+                <option value="">All</option>
+                <option value="true">Yes</option>
+                <option value="false">No</option>
+              </select>
+            </label>
+            <button className="secondary-button align-end" type="button" onClick={() => void loadEventDiagnostics()}>Apply filters</button>
+          </div>
+          <table className="data-table data-table--compact">
           <thead>
             <tr>
               <th>Event</th>
@@ -2158,6 +2321,7 @@ export function AdminGoNZBNetPage() {
                 <td className="breakable-value">{(item.pool_ids ?? []).join(', ') || 'local'}</td>
                 <td>
                   <span className="status-pill status-pill--table">{item.validation_status}</span>
+                  {item.tombstoned ? <div className="muted-copy">tombstoned</div> : null}
                   {item.rejection_reason ? <div className="muted-copy breakable-value">{item.rejection_reason}</div> : null}
                 </td>
                 <td>{item.projected ? formatDateTime(item.projected_at) : 'no'}</td>
@@ -2165,7 +2329,8 @@ export function AdminGoNZBNetPage() {
               </tr>
             ))}
           </tbody>
-        </table>
+          </table>
+        </div>
       </SectionTable>
 
       <SectionTable title="Rejected event rates" count={rejectedSummary.length}>

--- a/ui/src/shared/api/admin.ts
+++ b/ui/src/shared/api/admin.ts
@@ -45,6 +45,7 @@ import type {
   GoNZBNetCoverageSuggestionParams,
   GoNZBNetConfigValidation,
   GoNZBNetEventDiagnostic,
+  GoNZBNetEventDiagnosticParams,
   GoNZBNetGroupCatalogItem,
   GoNZBNetHealthAttestationDiagnostic,
   GoNZBNetKeyExportRequest,
@@ -75,6 +76,8 @@ import type {
   GoNZBNetPoolMemberRequest,
   GoNZBNetPoolHealthReport,
   GoNZBNetRejectedEventDiagnosticsResponse,
+  GoNZBNetReleaseLedgerParams,
+  GoNZBNetReleaseLedgerResponse,
   GoNZBNetReleaseSourceDiagnostic,
   GoNZBNetReputationDiagnostic,
   GoNZBNetRolePoolAccess,
@@ -460,7 +463,7 @@ export function reenrichAdminRelease(id: string) {
   })
 }
 
-function goNZBNetQuery(params: Record<string, string | number | undefined> = {}) {
+function goNZBNetQuery(params: Record<string, string | number | boolean | undefined> = {}) {
   const query = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined || value === "") {
@@ -599,9 +602,9 @@ export function getGoNZBNetPeerDiagnostics(limit = 100) {
   )
 }
 
-export function getGoNZBNetEventDiagnostics(limit = 100) {
+export function getGoNZBNetEventDiagnostics(params: GoNZBNetEventDiagnosticParams = {}) {
   return apiRequest<GoNZBNetListResponse<GoNZBNetEventDiagnostic>>(
-    `/api/v1/admin/gonzbnet/diagnostics/events${goNZBNetQuery({ limit })}`,
+    `/api/v1/admin/gonzbnet/diagnostics/events${goNZBNetQuery(params)}`,
   )
 }
 
@@ -632,6 +635,12 @@ export function getGoNZBNetBinaryEvidenceDiagnostics(poolID?: string, limit = 10
 export function getGoNZBNetReleaseSourceDiagnostics(poolID?: string, limit = 100) {
   return apiRequest<GoNZBNetListResponse<GoNZBNetReleaseSourceDiagnostic>>(
     `/api/v1/admin/gonzbnet/diagnostics/release-sources${goNZBNetQuery({ pool_id: poolID, limit })}`,
+  )
+}
+
+export function getGoNZBNetReleaseLedger(params: GoNZBNetReleaseLedgerParams = {}) {
+  return apiRequest<GoNZBNetReleaseLedgerResponse>(
+    `/api/v1/admin/gonzbnet/diagnostics/releases${goNZBNetQuery(params)}`,
   )
 }
 

--- a/ui/src/shared/types.ts
+++ b/ui/src/shared/types.ts
@@ -1776,6 +1776,17 @@ export type GoNZBNetEventDiagnostic = {
   rejection_reason?: string
   projected: boolean
   projected_at?: string
+	tombstoned: boolean
+}
+
+export type GoNZBNetEventDiagnosticParams = {
+	pool_id?: string
+	node_id?: string
+	event_type?: string
+	validation_status?: string
+	projected?: boolean
+	tombstoned?: boolean
+	limit?: number
 }
 
 export type GoNZBNetRejectedEventDiagnostic = {
@@ -2077,6 +2088,47 @@ export type GoNZBNetReleaseSourceDiagnostic = {
   posted_at?: string
   first_seen_at: string
   last_seen_at: string
+}
+
+export type GoNZBNetReleaseLedgerItem = {
+  release_id: string
+  manifest_id: string
+  projected_title: string
+  signed_title: string
+  projection_matches_signed_event: boolean
+  source_node_id: string
+  source_event_id: string
+  source_body_hash: string
+  pool_id: string
+  node_status: string
+  membership_status: string
+  publication_state: string
+  publication_event_id?: string
+  publication_reason?: string
+  publication_changed_at?: string
+  tombstone_target_type?: string
+  tombstone_target_id?: string
+  tombstone_severity?: string
+  tombstone_source_event_id?: string
+  effective_state: 'active' | 'withdrawn' | 'blocked' | 'revoked' | 'tombstoned' | 'projection_mismatch'
+  posted_at?: string
+  first_seen_at: string
+  last_seen_at: string
+}
+
+export type GoNZBNetReleaseLedgerResponse = {
+  items: GoNZBNetReleaseLedgerItem[]
+  count: number
+  next_cursor?: string
+}
+
+export type GoNZBNetReleaseLedgerParams = {
+  pool_id?: string
+  node_id?: string
+  release_id?: string
+  state?: string
+  cursor?: string
+  limit?: number
 }
 
 export type GoNZBNetManifestSourceDiagnostic = {


### PR DESCRIPTION
## Summary

  This PR hardens GoNZBNet against modified release metadata, poisoned manifest caches, cross-pool provenance confusion, unauthorized manifest sources, and
  destructive tombstone behavior.

  It also adds operator diagnostics for inspecting active, withdrawn, blocked, invalid, and tombstoned releases/events.

  ## Key changes

  - Validate projected ReleaseCard metadata against the original signed event.
  - Exclude releases with locally modified titles, sizes, IDs, or other signed fields from search and grabs.
  - Bind manifest responses to the requested release, manifest, pool, request ID, and authorized source.
  - Run complete typed event-body validation during manifest resolution.
  - Recheck membership, capabilities, trust, node blocking, withdrawal, and tombstones before fetch or cache use.
  - Rehash cached NZB bytes before returning them.
  - Repair altered NZB caches deterministically from the verified signed manifest.
  - Reject or remotely refetch caches with invalid signed-event provenance.
  - Preserve the exact signed manifest event per manifest, pool, and author.
  - Make expiring tombstones reversible and non-destructive.
  - Require explicit federation publication for uploader releases; approval alone no longer creates duplicate ReleaseCards.
  - Add release/event integrity diagnostics and corresponding admin UI filters.

  ## Manifest provenance

  Manifest content remains deduplicated by its stable manifest ID. A new resolution_manifest_events mapping retains the signed envelope independently for
  each pool and author.

  This prevents publishing identical manifest content to a second pool from overwriting the signed event required to serve the first pool.

  Dedicated manifest-fetch authorization is intentionally separate from the pool’s general relay event policy. Resolution manifests can therefore be fetched
  securely without enabling them as general gossip events.

  ## Moderation behavior

  Tombstones now act as dynamic suppression policy instead of mutating accepted data.

  An active tombstone suppresses search, grabs, and manifest serving while preserving:

  - the signed ReleaseCard;
  - the accepted manifest;
  - the verified cached NZB;
  - the original federation events and audit history.

  When an expiring tombstone lapses, the release becomes eligible again if its publisher, membership, trust, publication state, and integrity checks still
  pass.

  ## Diagnostics

  The admin API and UI can inspect:

  - signed versus projected titles;
  - projection/signature agreement;
  - source event and body hash;
  - source node and pool;
  - membership and node status;
  - publication and withdrawal state;
  - active tombstones;
  - final effective release state;
  - accepted, rejected, projected, and tombstoned events.

  Relevant endpoints include:

  GET /api/v1/admin/gonzbnet/diagnostics/releases
  GET /api/v1/admin/gonzbnet/diagnostics/events
  GET /api/v1/admin/gonzbnet/moderation/tombstones

  ## Database migrations

  - 038_gonzbnet_integrity_hardening
      - Adds manifest fetch provenance and cache-integrity status.
      - Adds indexes for node-state, tombstone, and publication-state checks.

  - 039_gonzbnet_manifest_pool_provenance
      - Adds pool/author-specific signed manifest event mappings.
      - Backfills existing accepted ResolutionManifest events.
      - Adds indexed manifest and pool lookup paths.

  ## Security boundary

  These changes establish that returned metadata and NZBs match accepted signed events and manifests.

  They do not establish that a legitimate publisher supplied honest titles, safe Message-IDs, or malware-free Usenet content. Malicious but correctly signed
  publications still require trust policy, validation, moderation, publisher blocking, and pool-member revocation.

  ## Validation

  Completed successfully:

  - go test ./...
  - Full disposable-PostgreSQL CI suite
  - PostgreSQL query soak
  - UI production build
  - Clean four-node GoNZBNet E2E suite
  - Real uploader submission and explicit publication
  - Malformed NZB rejection
  - Release title and size projection tampering
  - PostgreSQL NZB cache tampering
  - Filesystem blob-cache tampering
  - Manifest provenance tampering
  - Publisher blocking and restoration
  - Expiring local tombstones
  - Pool-wide signed tombstone propagation

  Live cache soak:

  - 240 concurrent NZB grabs
  - 12 repeated searches
  - zero response or hash failures
  - zero additional peer manifest requests
  - zero additional cache-integrity failures

  Uploader regression validation confirmed that approval emits no ReleaseCard, explicit publication emits exactly one, and subsequent automatic publisher
  intervals do not create a duplicate.
